### PR TITLE
Fix all Dependabot alerts: sinatra 4.2.1, rack 3.2.6, Ruby 3.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM ruby:2.6.5
-
-RUN gem install bundler:2.1.4
+FROM ruby:3.4
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,15 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-# gem "rails"
-gem 'sinatra'
-gem 'json'
-gem 'java-properties'
+# sinatra >= 4.2.0 is the first release clear of CVE-2022-29970, CVE-2022-45442,
+# CVE-2024-21510 and CVE-2025-61921. It pulls rack 3.x, which also clears the
+# rack advisories (CVE-2022-30123 et al).
+gem 'sinatra', '~> 4.2'
+
+# Rack 3 moved Rack::Handler into the rackup gem and sinatra no longer bundles a
+# server, so classic mode (`ruby github_webhooks.rb`) needs both spelled out.
+gem 'rackup', '~> 2.3'
+gem 'puma', '~> 8.0'
+
+gem 'json', '~> 2.21'
+gem 'java-properties', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,44 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    java-properties (0.2.0)
-    json (2.3.0)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
-    rack (2.2.3)
-    rack-protection (2.0.8.1)
-      rack
-    ruby2_keywords (0.0.2)
-    sinatra (2.0.8.1)
-      mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.8.1)
+    base64 (0.3.0)
+    java-properties (0.3.0)
+    json (2.21.1)
+    logger (1.7.0)
+    mustermann (3.1.1)
+    nio4r (2.7.5)
+    puma (8.0.2)
+      nio4r (~> 2.0)
+    rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rackup (2.3.1)
+      rack (>= 3)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    tilt (2.0.10)
+    tilt (2.8.0)
 
 PLATFORMS
+  aarch64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
-  java-properties
-  json
-  sinatra
+  java-properties (~> 0.3)
+  json (~> 2.21)
+  puma (~> 8.0)
+  rackup (~> 2.3)
+  sinatra (~> 4.2)
 
 BUNDLED WITH
-   2.1.4
+   2.6.9

--- a/github_webhooks.rb
+++ b/github_webhooks.rb
@@ -37,6 +37,9 @@ require 'json'
 require 'java-properties'
 require 'uri'
 require 'net/http'
+# base64 is no longer a default gem as of Ruby 3.4, and repository_default's
+# Base64.strict_encode64 call would otherwise rely on a transitive require.
+require 'base64'
 
 ##################################################################################################
   #


### PR DESCRIPTION
Clears every open Dependabot alert on this repo. Supersedes #10 and #13.

## Why this couldn't stay on 2.x

Dependabot's suggested targets (`sinatra ~> 2.2.0`, `rack ~> 2.2.3.1`) are per-alert minimums and don't clear the set:

| Advisory | Severity | Fixed in |
|---|---|---|
| CVE-2022-29970 (path traversal) | High | sinatra 2.2.0 |
| CVE-2022-45442 (reflected file download) | High | sinatra 2.2.3 |
| CVE-2024-21510 (untrusted `X-Forwarded-Host`) | Moderate | **sinatra 4.1.0** |
| CVE-2025-61921 (ETag ReDoS) | Low | **sinatra 4.2.0** |

sinatra 4.x requires `rack >= 3.0` and Ruby `>= 2.7.8`, so rack and the base image move with it. Ruby 2.6.5 is EOL and receives no security patches regardless.

## Changes

- `sinatra` 2.0.8.1 → **4.2.1**
- `rack` 2.2.3 → **3.2.6** — clears all **32** advisories present on 2.2.3, including CVE-2022-30123 (critical) and CVE-2025-27610
- `json` 2.3.0 → 2.21.1, `java-properties` 0.2.0 → 0.3.0, `tilt` 2.0.10 → 2.8.0
- Dockerfile `ruby:2.6.5` → `ruby:3.4`; dropped the `bundler:2.1.4` pin (image ships a current bundler)
- Added `rackup` + `puma` explicitly — Rack 3 moved `Rack::Handler` into `rackup`, and sinatra 4 no longer bundles a server, so classic mode (`ruby github_webhooks.rb`) needs both
- Added `require 'base64'` — no longer a default gem as of Ruby 3.4; `Base64.strict_encode64` in `repository_default` was relying on a transitive require from rack-protection
- Pinned all gems with `~>` so future resolves are reproducible
- Added `.github/dependabot.yml` for weekly grouped bundler / docker / github-actions updates

## Verification

The repo has no test suite, so this was verified by build + live smoke test:

- **OSV scan: 0 advisories** across all 13 resolved gems (was 36 across sinatra + rack)
- `docker build` clean
- Container boots: `Sinatra (v4.2.1) ... with backup from Puma`, Ruby 3.4.10, listening on `0.0.0.0:4567` (the `-o 0.0.0.0` CMD arg still works)
- `POST /github_webhook` → **200** for a non-repository object and for `repository`/`deleted`, both logging `[INFO] Ignoring object = ...` — so routing, `request.body.read`, and `$stdout.sync` docker logging all survive the Sinatra 2 → 4 jump
- `GET /nope` → **404**
- `JavaProperties.load` symbol-key access and `Base64.strict_encode64` confirmed working under Ruby 3.4

**Not exercised:** `repository_default`, which calls the live GitHub API and needs a real token. It only uses `Net::HTTP`, `JSON`, `JavaProperties`, and `Base64` — no Sinatra/Rack surface — and each of those was checked individually above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)