### PR TITLE
Publish a multi-arch image, gate every change with CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.gitignore
+.webhook_properties
+webhook_json.log
+.DS_Store
+README.md
+LICENSE
+build.sh
+docker-compose.yml
+*.postman_collection.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  image:
+    name: Build image and smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: github-webhooks:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start container
+        run: |
+          printf 'githubToken=dummy-token-for-ci\n' > "$RUNNER_TEMP/webhook_properties"
+          docker run -d --name gw-ci -p 4567:4567 \
+            -v "$RUNNER_TEMP/webhook_properties:/usr/src/app/.webhook_properties" \
+            github-webhooks:ci
+          ./script/wait_for_http.sh http://127.0.0.1:4567/ 45
+          docker logs gw-ci
+
+      - name: Smoke test
+        run: ./script/smoke_test.sh http://127.0.0.1:4567 gw-ci
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f gw-ci || true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,56 @@
+name: Publish
+
+# Replaces the Docker Hub autobuild referenced in build.sh, which stopped
+# running in 2020 and left the published image six years stale.
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Push multi-arch image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Secrets are not available to job-level `if:`, so gate the push on a step
+      # output instead. Without this the workflow would fail red on every merge
+      # until the Docker Hub credentials are added.
+      - name: Check for Docker Hub credentials
+        id: creds
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Skipping publish -- set the DOCKERHUB_USERNAME and DOCKERHUB_TOKEN repository secrets (Settings > Secrets and variables > Actions) to enable it."
+          fi
+
+      - uses: docker/setup-qemu-action@v3
+        if: steps.creds.outputs.present == 'true'
+
+      - uses: docker/setup-buildx-action@v3
+        if: steps.creds.outputs.present == 'true'
+
+      - uses: docker/login-action@v3
+        if: steps.creds.outputs.present == 'true'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        if: steps.creds.outputs.present == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            jimzucker/github-webhooks:latest
+            jimzucker/github-webhooks:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,13 +30,13 @@ jobs:
             echo "::warning::Skipping publish -- set the DOCKERHUB_USERNAME and DOCKERHUB_TOKEN repository secrets (Settings > Secrets and variables > Actions) to enable it."
           fi
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
         if: steps.creds.outputs.present == 'true'
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         if: steps.creds.outputs.present == 'true'
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: steps.creds.outputs.present == 'true'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build and push
         if: steps.creds.outputs.present == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,30 @@
-FROM ruby:3.4
+FROM ruby:3.4-slim AS builder
+
+# puma and nio4r ship native extensions, so the build stage needs a compiler.
+# It is thrown away -- only the resolved bundle is copied into the runtime stage.
+RUN apt-get update -qq \
+ && apt-get install -y --no-install-recommends build-essential \
+ && rm -rf /var/lib/apt/lists/*
 
 # throw errors if Gemfile has been modified since Gemfile.lock
-RUN bundle config --global frozen 1
+ENV BUNDLE_FROZEN=true
 
 WORKDIR /usr/src/app
 
-COPY Gemfile Gemfile.lock github_webhooks.rb ./
-RUN bundle install
+COPY Gemfile Gemfile.lock ./
+RUN bundle install && rm -rf /usr/local/bundle/cache
 
+
+FROM ruby:3.4-slim AS runtime
+
+ENV BUNDLE_FROZEN=true
+
+WORKDIR /usr/src/app
+
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+COPY Gemfile Gemfile.lock github_webhooks.rb ./
 COPY config ./config
 
-CMD ["/usr/local/bin/ruby", "./github_webhooks.rb", "-o", "0.0.0.0"]
+EXPOSE 4567
 
+CMD ["/usr/local/bin/ruby", "./github_webhooks.rb", "-o", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ docker run --rm -ti -p 4567:4567 -v $PWD/.webhook_properties:/usr/src/app/.webho
 You change the parameters for the webhooks by creating a local copy over overriting the config directory
 
 ```
-version: '3.4'
 services:
   github-webhooks:
     image: jimzucker/github-webhooks:latest
@@ -48,12 +47,14 @@ services:
     restart: unless-stopped
     ports:
       - 4567:4567
+    volumes:
+      - $PWD/.webhook_properties:/usr/src/app/.webhook_properties
 # you can copy configs locally and then override with:
 #  docker cp github-webhooks:/usr/src/app/config .
-    volumes:
-      - $PWD/webhook_properties:/usr/src/app/.webhook_properties
 #      - $PWD/config:/usr/src/app/config
 ```
+
+See `docker-compose.yml` in the repo for the maintained copy.
 ---
 
 ## Default webhook settings
@@ -61,7 +62,7 @@ services:
 ##### Repository Settings
 
 File: config/new_repo_config.json<br>
-Reference: https://developer.github.com/v3/repos/?#edit
+Reference: https://docs.github.com/en/rest/repos/repos#update-a-repository
 
 ```
 {
@@ -75,7 +76,7 @@ Reference: https://developer.github.com/v3/repos/?#edit
 ##### Branch Protection
 
 File: config/new_master_branch_config.json<br>
-Reference: https://developer.github.com/v3/repos/branches/#update-branch-protection
+Reference: https://docs.github.com/en/rest/branches/branch-protection#update-branch-protection
 
 ```
 { 
@@ -108,16 +109,48 @@ https://github.com/jimzucker/github-webhooks
 
 ##### Instructions to run Manually outside of Docker from github source
 
-> 1. To start the server and it will monitor on port 4567
-> 	ruby github-webhooks.rb
->   Note: you must create a file .webhook_properties with 1 entry
->   githubToken=<github api token>
-> 
-> 2. To expose your ports for development
-> ./ngrok http 4567
-> 
-> 3. To setup the webhook in GitHub
-> https://<URL to server that maps to 4567>/github_webhook
+Requires Ruby 3.4 or newer (see the `Dockerfile` for the version this is built and tested against).
+
+1. Install the dependencies:
+
+   ```
+   bundle install
+   ```
+
+2. Create a file `.webhook_properties` with one entry:
+
+   ```
+   githubToken=<github api token>
+   ```
+
+3. Start the server; it listens on port 4567:
+
+   ```
+   bundle exec ruby github_webhooks.rb
+   ```
+
+4. To expose your port for development:
+
+   ```
+   ./ngrok http 4567
+   ```
+
+5. Set the webhook payload URL in GitHub to:
+
+   ```
+   https://<URL to server that maps to 4567>/github_webhook
+   ```
+
+##### Building the image
+
+Every merge to `master` publishes a multi-architecture (`linux/amd64` + `linux/arm64`) image to Docker Hub via `.github/workflows/publish.yml`, so you normally do not need to build by hand. For local one-offs:
+
+```
+./build.sh --local   # build for this machine only
+./build.sh --push    # build both architectures and push to Docker Hub
+```
+
+`build.sh` deliberately refuses to do a plain single-arch `docker build` and push: on an Apple Silicon Mac that would replace the published `amd64` image with an `arm64`-only one.
 
 ##### Postman Reference
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,34 @@
 #!/bin/sh
-docker build -t github-webhooks .
-docker tag github-webhooks jimzucker/github-webhooks:latest
-#docker hub has CI when we push`
-#docker push jimzucker/github-webhooks:latest
-exit 0
+# Build and publish the image for both architectures.
+#
+# A plain `docker build` on an Apple Silicon Mac produces a linux/arm64 image
+# only. Pushing that would replace the published amd64 image and break amd64
+# deployments, so this always goes through buildx with an explicit platform
+# list. buildx cannot --load a multi-platform result into the local daemon,
+# which is why publishing and local builds are separate paths below.
+#
+# Normally you do not need to run this at all: .github/workflows/publish.yml
+# does the same multi-arch push on every merge to master.
+set -e
+
+IMAGE=jimzucker/github-webhooks
+PLATFORMS=linux/amd64,linux/arm64
+
+case "$1" in
+  --push)
+    docker buildx build --platform "$PLATFORMS" -t "$IMAGE:latest" --push .
+    echo "Pushed $IMAGE:latest for $PLATFORMS"
+    ;;
+  --local)
+    # Single-arch, native to this machine, loaded into the local daemon.
+    docker buildx build -t github-webhooks:latest --load .
+    echo "Built github-webhooks:latest for local use (this architecture only)"
+    ;;
+  *)
+    echo "usage: $0 --local | --push"
+    echo "  --local  build for this machine and load into the local daemon"
+    echo "  --push   build linux/amd64 + linux/arm64 and push to Docker Hub"
+    echo "           (requires 'docker login')"
+    exit 1
+    ;;
+esac

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+# The top-level `version:` key is obsolete in Compose v2 and now warns; omitted.
 services:
   github-webhooks:
     image: jimzucker/github-webhooks:latest
@@ -6,8 +6,8 @@ services:
     restart: unless-stopped
     ports:
       - 4567:4567
+    volumes:
+      - $PWD/.webhook_properties:/usr/src/app/.webhook_properties
 # you can copy configs locally and then override with:
 #  docker cp github-webhooks:/usr/src/app/config .
-    volumes:
-      - $PWD/webhook_properties:/usr/src/app/.webhook_properties
 #      - $PWD/config:/usr/src/app/config

--- a/script/smoke_test.sh
+++ b/script/smoke_test.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# End-to-end smoke test against a running container.
+#
+# Used by .github/workflows/ci.yml and runnable by hand:
+#   ./script/smoke_test.sh http://127.0.0.1:4567 gw-ci
+#
+# Args:
+#   $1  base URL of the running server (default http://127.0.0.1:4567)
+#   $2  docker container name to pull logs from (optional; enables log assertions)
+set -eu
+
+BASE="${1:-http://127.0.0.1:4567}"
+CONTAINER="${2:-}"
+
+failures=0
+
+logs() {
+  [ -n "$CONTAINER" ] && docker logs "$CONTAINER" 2>&1 || true
+}
+
+check() {
+  label="$1"
+  expected="$2"
+  actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "ok    $label (HTTP $actual)"
+  else
+    echo "FAIL  $label: expected HTTP $expected, got $actual"
+    failures=$((failures + 1))
+  fi
+}
+
+post() {
+  curl -s -o /dev/null -w '%{http_code}' \
+    -X POST "$BASE/github_webhook" \
+    -H 'Content-Type: application/json' \
+    -H "X-GitHub-Event: $1" \
+    -d "$2"
+}
+
+get() {
+  curl -s -o /dev/null -w '%{http_code}' "$BASE$1"
+}
+
+echo "--- smoke test against $BASE ---"
+
+# An event we do not act on: exercises routing and request.body.read without
+# touching the GitHub API.
+check "POST /github_webhook (non-repository object)" 200 \
+  "$(post organization '{"action":"created","organization":{"login":"acme"}}')"
+
+# A repository event with an action we ignore: one level deeper, still no API call.
+check "POST /github_webhook (repository/deleted)" 200 \
+  "$(post repository '{"action":"deleted","repository":{"full_name":"acme/demo","default_branch":"main"}}')"
+
+check "GET /nope (unknown route)" 404 "$(get /nope)"
+
+# $stdout.sync must keep working or docker logs go silent -- see issue #6.
+if [ -n "$CONTAINER" ]; then
+  if logs | grep -q '\[INFO\] Ignoring object'; then
+    echo "ok    [INFO] output reaches docker logs"
+  else
+    echo "FAIL  no [INFO] output in docker logs (\$stdout.sync regression?)"
+    failures=$((failures + 1))
+  fi
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "--- $failures check(s) failed; container logs follow ---"
+  logs
+  exit 1
+fi
+
+echo "--- all checks passed ---"

--- a/script/wait_for_http.sh
+++ b/script/wait_for_http.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Block until an HTTP server answers at all, or time out.
+#
+# Any response counts as up -- the app has no route for /, so a 404 is the
+# expected success signal here. Only a connection failure (curl exit 7) means
+# the server has not started yet.
+#
+#   ./script/wait_for_http.sh http://127.0.0.1:4567/ 45
+set -eu
+
+URL="${1:?usage: wait_for_http.sh URL [seconds]}"
+TIMEOUT="${2:-45}"
+
+i=0
+while [ "$i" -lt "$TIMEOUT" ]; do
+  if curl -s -o /dev/null "$URL" 2>/dev/null; then
+    echo "$URL responded after ${i}s"
+    exit 0
+  fi
+  i=$((i + 1))
+  sleep 1
+done
+
+echo "timed out after ${TIMEOUT}s waiting for $URL" >&2
+exit 1


### PR DESCRIPTION
The CVE fix in #14 was never actually shipped. Docker Hub `jimzucker/github-webhooks:latest` is still the single-arch image built **2020-09-21** — the autobuild `build.sh` refers to has not run since. Anyone following the README still pulls the vulnerable image.

**No app behavior changes in this PR.** `github_webhooks.rb` is untouched.

## Publishing

- **`.github/workflows/publish.yml`** (new) — multi-arch (`linux/amd64` + `linux/arm64`) push to Docker Hub on every merge to `master`, tagged `:latest` and `:<sha>`. Replaces the dead autobuild.
- **`build.sh`** rewritten with explicit `--local` / `--push` modes. The old script did a plain `docker build` and tagged it for the hub — run on an Apple Silicon Mac that produces **arm64 only**, so pushing it would have replaced the published amd64 image and broken amd64 deployments. `--push` always goes through buildx with both platforms. Now executable.

> [!IMPORTANT]
> **Action required before publishing works:** add repository secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` under Settings → Secrets and variables → Actions. Generate the token at hub.docker.com → Account Settings → Personal access tokens with Read/Write scope.
>
> Until then the publish job **warns and skips** rather than failing red — secrets aren't readable from a job-level `if:`, so it's gated on a step output instead.

## CI

- **`.github/workflows/ci.yml`** (new) — builds the image and smoke tests it on every PR.
- **`script/smoke_test.sh`** and **`script/wait_for_http.sh`** extracted so CI and local runs execute the *identical* checks instead of a copy that drifts. Run it yourself with `./script/smoke_test.sh http://127.0.0.1:4567 <container>`.

## Image size

Multi-stage build on `ruby:3.4-slim`, compiler confined to the build stage (`puma` and `nio4r` have native extensions):

| | before | after |
|---|---|---|
| arm64 | 1.65 GB | **286 MB** |
| amd64 | 1.64 GB | **259 MB** |

Also added `.dockerignore` so `.git` stays out of the build context.

## Fixes found along the way

- `docker-compose.yml` mounted `$PWD/webhook_properties` while the README documented `$PWD/.webhook_properties` — the latter is what the app actually loads, so the committed compose file could never have worked as-is.
- Dropped the obsolete top-level `version:` key (Compose v2 warns on it).
- README: `ruby github-webhooks.rb` is the wrong filename (it's `github_webhooks.rb`); added the missing `bundle install` step; replaced dead `developer.github.com` links with `docs.github.com`.

## Verification

- `docker buildx build --platform linux/amd64,linux/arm64` — both arches compile the native extensions.
- `script/smoke_test.sh` passes against the slim image on **both** arm64 and amd64: Sinatra 4.2.1 / Ruby 3.4.10, `POST /github_webhook` → 200 on two ignore paths, `GET /nope` → 404, and `[INFO]` output confirmed reaching `docker logs` (guards the `$stdout.sync` fix from #6).
- Failure path checked too — the script exits non-zero and dumps container logs when a check fails.
- No dependency changes, so the 0-advisory OSV result from #14 still stands.

Next in the series: the latent bugs in `github_webhooks.rb` (unauthenticated endpoint, `exit(1)` inside the request path, `sleep(30)` exceeding GitHub's 10s delivery timeout, hardcoded `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)