### PR TITLE
Fix latent bugs in webhook handling; add a test suite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,6 @@ LICENSE
 build.sh
 docker-compose.yml
 *.postman_collection.json
+spec
+script
+Rakefile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,19 @@ on:
     branches: [master]
 
 jobs:
+  specs:
+    name: Specs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - run: bundle exec rake
+
   image:
     name: Build image and smoke test
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update -qq \
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 ENV BUNDLE_FROZEN=true
+# Test-only gems have no business in the runtime image.
+ENV BUNDLE_WITHOUT=test
 
 WORKDIR /usr/src/app
 
@@ -18,11 +20,13 @@ RUN bundle install && rm -rf /usr/local/bundle/cache
 FROM ruby:3.4-slim AS runtime
 
 ENV BUNDLE_FROZEN=true
+ENV BUNDLE_WITHOUT=test
 
 WORKDIR /usr/src/app
 
 COPY --from=builder /usr/local/bundle /usr/local/bundle
-COPY Gemfile Gemfile.lock github_webhooks.rb ./
+COPY Gemfile Gemfile.lock config.ru github_webhooks.rb ./
+COPY lib ./lib
 COPY config ./config
 
 EXPOSE 4567

--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,11 @@ gem 'puma', '~> 8.0'
 
 gem 'json', '~> 2.21'
 gem 'java-properties', '~> 0.3'
+
+# Excluded from the runtime image via BUNDLE_WITHOUT in the Dockerfile.
+group :test do
+  gem 'minitest', '~> 6.0'
+  gem 'rack-test', '~> 2.2'
+  gem 'rake', '~> 13.4'
+  gem 'webmock', '~> 3.26'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
+    bigdecimal (4.1.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    drb (2.2.3)
+    hashdiff (1.2.1)
     java-properties (0.3.0)
     json (2.21.1)
     logger (1.7.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     mustermann (3.1.1)
     nio4r (2.7.5)
+    prism (1.9.0)
+    public_suffix (7.0.5)
     puma (8.0.2)
       nio4r (~> 2.0)
     rack (3.2.6)
@@ -17,8 +30,12 @@ GEM
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
     rackup (2.3.1)
       rack (>= 3)
+    rake (13.4.2)
+    rexml (3.4.4)
     sinatra (4.2.1)
       logger (>= 1.6.0)
       mustermann (~> 3.0)
@@ -27,6 +44,10 @@ GEM
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
     tilt (2.8.0)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   aarch64-linux
@@ -36,9 +57,13 @@ PLATFORMS
 DEPENDENCIES
   java-properties (~> 0.3)
   json (~> 2.21)
+  minitest (~> 6.0)
   puma (~> 8.0)
+  rack-test (~> 2.2)
   rackup (~> 2.3)
+  rake (~> 13.4)
   sinatra (~> 4.2)
+  webmock (~> 3.26)
 
 BUNDLED WITH
    2.6.9

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # github-webhooks
-Web service that listens for organization events to know when a repository has been created. When the repository is created please automate the protection of the master branch. Notify yourself with an @mention in an issue within the repository that outlines the protections that were added.
+Web service that listens for organization events to know when a repository has been created. When the repository is created it automates the protection of the repository's default branch, and notifies you with an @mention in an issue within the repository that outlines the protections that were added.
 
 You can run the webhooks in docker, see https://hub.docker.com/r/jimzucker/github-webhooks, or you can run the server directly from Github, instructions are at the end of the readme.
 
@@ -9,10 +9,24 @@ You can run the webhooks in docker, see https://hub.docker.com/r/jimzucker/githu
 * Allow merge commits
 * Squash commits are not allowed
 
-##### Master Branch
-* Pull requests are required to merge to master
-* Do not allow re-writting history
+##### Default branch
+* Pull requests are required to merge
+* Do not allow re-writing history
 * Restrictions are applied to administrators
+
+The branch is read from `repository.default_branch` in the webhook payload, so this works for repositories that default to `main` as well as older ones on `master`.
+
+##### Responses
+
+`POST /github_webhook` answers immediately and does the GitHub API work on a background thread, because GitHub only allows a webhook 10 seconds to respond:
+
+| Status | Meaning |
+| --- | --- |
+| `202` | Accepted; repository setup is running in the background (watch the logs) |
+| `200` | Received, but this is not an event the service acts on |
+| `400` | Body was not a JSON object |
+
+Because the work is in-flight rather than queued, a restart loses any setup that had not finished. Check the logs after creating a repository.
 
 
 ##### Configuration
@@ -140,6 +154,25 @@ Requires Ruby 3.4 or newer (see the `Dockerfile` for the version this is built a
    ```
    https://<URL to server that maps to 4567>/github_webhook
    ```
+
+##### Running the tests
+
+```
+bundle install
+bundle exec rake
+```
+
+##### Layout
+
+| Path | Purpose |
+| --- | --- |
+| `github_webhooks.rb` | entry point; parses `-o`/`-p` and starts the server |
+| `config.ru` | Rack entry point, for `bundle exec rackup` |
+| `lib/github_webhooks/app.rb` | routes and event dispatch |
+| `lib/github_webhooks/github_client.rb` | GitHub REST API calls |
+| `lib/github_webhooks/repository_defaults.rb` | the new-repository workflow |
+| `lib/github_webhooks/settings.rb` | reads `.webhook_properties` |
+| `spec/` | Minitest + rack-test suite |
 
 ##### Building the image
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'lib' << 'spec'
+  t.pattern = 'spec/**/*_spec.rb'
+  t.warning = false
+end
+
+task default: :test

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Rack entry point, for running under any Rack server:
+#
+#   bundle exec rackup
+#
+# The Dockerfile uses github_webhooks.rb instead, which starts Puma directly and
+# accepts -o/-p. Both paths boot the same GithubWebhooks::App.
+
+$stdout.sync = true
+
+require_relative 'lib/github_webhooks/app'
+
+GithubWebhooks::App.configure!(GithubWebhooks::Settings.load)
+
+run GithubWebhooks::App

--- a/github_webhooks.rb
+++ b/github_webhooks.rb
@@ -1,212 +1,48 @@
 #!/usr/local/bin/ruby
-# simple webhook demo, see https://developer.github.com/webhooks/configuring/
+# frozen_string_literal: true
+
+# Entry point for running the webhook server directly:
 #
-# Pre Requisites
-# --------------
-# install ngrok see: https://ngrok.com
-# install ruby on my mac correctly:https://stackify.com/install-ruby-on-your-mac-everything-you-need-to-get-going/
-#   /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-#  Step 1: brew install ruby
-#  #update your profile per the output of the brew install
-#    #If you need to have ruby first in your PATH run:
-#      echo 'export PATH="/usr/local/opt/ruby/bin:$PATH"' >> ~/.zshrc
-#    
-#     #For compilers to find ruby you may need to set:
-#      export LDFLAGS="-L/usr/local/opt/ruby/lib"
-#      export CPPFLAGS="-I/usr/local/opt/ruby/include"
-#    #For pkg-config to find ruby you may need to set:
-#      export PKG_CONFIG_PATH="/usr/local/opt/ruby/lib/pkgconfig"
+#   bundle exec ruby github_webhooks.rb [-o ADDR] [-p PORT]
 #
-#  #install sinatra-contrib dependency
-#    gem install sinatra-contrib
-#
-#
-# Run
-# -----------
-# expose port: ./ngrok http 4567
-#
-# Configure webhook with output from ngrok: 
-#  <ngrok url>/payload #set payload type to JSON
-#  example: https://78e4671d.ngrok.io/payload
-#
-# start the server: ruby server.rb
-#
-#
-require 'sinatra'
-require 'json'
-require 'java-properties'
-require 'uri'
-require 'net/http'
-# base64 is no longer a default gem as of Ruby 3.4, and repository_default's
-# Base64.strict_encode64 call would otherwise rely on a transitive require.
-require 'base64'
+# The application itself lives in lib/github_webhooks/. See README.md for setup,
+# and https://docs.github.com/en/webhooks for configuring the webhook in GitHub.
 
-##################################################################################################
-  #
-  # utilties
-  #
-
-def read_properties()
-  if(File.exist?('.webhook_properties'))
-    return JavaProperties.load('.webhook_properties')
-  else
-    puts '[ERROR] You must have a java style properties file .webhook_properties with githubToken=xx defined'
-    exit(1)
-  end
-end
-
-def read_config_file(config_file) 
-  config_file = 'config/' + config_file
-  if(File.exist?(config_file)) 
-    json_body =  File.read(config_file)
-  else 
-    puts '[ERROR] ' + config_file + ' file missing'
-    exit(1)
-  end
-  return json_body
-end
-
-def exec_request(method, success_code, url, request_body, message, exit_on_error) 
-  properties = read_properties()
-  url = 'https://api.github.com/' + url
-  puts "[INFO] #{message}:  method= #{method}, url= #{url}"
-
-  uri = URI(url)
-  case method
-    when 'Get'
-      request = Net::HTTP::Get.new(uri)
-    when 'Patch'
-      request = Net::HTTP::Patch.new(uri)
-    when 'Post'
-      request = Net::HTTP::Post.new(uri)
-    when 'Put'
-      request = Net::HTTP::Put.new(uri)
-    else
-      puts "[ERROR] unknow method: #{method}"
-      exit(1)
-  end
-
-  #build request
-  request['Authorization'] = 'token ' + properties[:githubToken]
-  request['Content-Type'] = 'application/json'
-  request["Accept"] = "application/vnd.github.luke-cage-preview+json"  #required for experimental features
-  request.body = request_body
-
-  https = Net::HTTP.new(uri.host, uri.port)
-  https.use_ssl = true
-  response =  https.request(request)
-  if !response.code.eql?(success_code) && exit_on_error
-    puts '[ERROR] Executing http call, result code = ' + response.code + ' url= ' + url
-    puts response.read_body
-    exit(1)
-  end
-  return response
-end
-##################################################################################################
-
-##################################################################################################
-  #
-  # process events for repositories
-  #
-def repository_default(webhook_action, webhook_object,webhook_payload)
-
-  #partse params
-  repository_full_name = webhook_payload['repository']['full_name']
-  sender_login = webhook_payload['sender']['login']
-  puts "[INFO] Processing object= #{webhook_object}, action= #{webhook_action} on repo= #{repository_full_name} by #{sender_login}"
-
-
-  #get authorized user info
-  response = exec_request('Get','200','user', '','Getting Authorized User', true)
-  authorized_user_json = JSON.parse(response.read_body)
-  authorized_user_login = authorized_user_json['login']
-  authorized_user_name = authorized_user_json['name']
-  authorized_user_email = authorized_user_json['email']    #returns nil if Primary email is not public
-  if ! authorized_user_email
-    puts "[ERROR] Primary email address must be public which provides an email entry for /user endpoint for authorized user executing webhook, user_login=#{authorized_user_login}"
-    puts authorized_user_response.read_body
-    exit(1)
-  end
-
-  #sleep to ensure readme creation is completed, we see instability in timing
-  sleep(30)
-
-  #check if readme exists, if not create it
-  response = exec_request('Get','200',"repos/#{repository_full_name}/contents/README.md", '', 'Checking existance of README.md', false)
-  if !response.code.eql?('200')
-    #add a README.md if one does not exist, see issue #2 branch protection API cannot work if repo is empty
-    readme_content_base64=Base64.strict_encode64("\# #{repository_full_name}")
-    readme_config = "{\"message\": \"my commit message\",  \"sender_login\": \{\"name\": \"#{authorized_user_name}\",\"email\": \"#{authorized_user_name}\" \}, \"content\": \"#{readme_content_base64}\"}"
-    response = exec_request('Put','201',"repos/#{repository_full_name}/contents/README.md", readme_config, 'Creating README.md(Note:repository must be initialized for branch permissions api to work).', true)
-  end
-
-  #set repo defaults (Must due this after creating readme)
-  repo_config = read_config_file('new_repo_config.json')
-  response = exec_request('Patch','200',"repos/#{repository_full_name}", repo_config, 'Defaulting Repository Settings', true)
-
-  #protect master branch 
-  branch_config = read_config_file('new_master_branch_config.json')
-  response = exec_request('Put','200',"repos/#{repository_full_name}/branches/master/protection", branch_config, 'Protecting master branch', true)
-
-  #add an issue to document the changes
-  request_body = "{\"title\": \"Ran webook to default repository settings & protected master branch\",\"body\" : \" @#{authorized_user_login} set default respository settings and protected the master branch.\"}"
-  response = exec_request('Post','201',"repos/#{repository_full_name}/issues", request_body, 'Defaulting Repository Settings', true)
-
-end
-
-def repository_webhook(webhook_action, webhook_object, webhook_payload)
-  #validate inputs
-  if ! webhook_object.casecmp?('repository') 
-    puts "[ERROR] Invalid call to repository_webhook for object = #{webhook_object}"
-    exit(1)
-  end
-
-  # we want to only take action on the 'created' event on a repository
-  # Project created, updated, or deleted
-  # Note: When a repository is created we can get many other events depending on how the webhook is configured
-  #  so we will ingore them
-  case webhook_action.downcase
-    when 'created'
-      repository_default(webhook_action, webhook_object,webhook_payload)
-    else
-      puts "[INFO] Ignoring object = #{webhook_object}, action = #{webhook_action}"
-  end
-end
-##################################################################################################
-
-##################################################################################################
-# Main hook
-#
-post '/github_webhook' do
-  webhook_payload = JSON.parse(request.body.read)
-
-  #Payloads https://developer.github.com/v3/activity/events/types/
-  webhook_action = webhook_payload['action']
-  webhook_keys = webhook_payload.keys
-  webhook_object = webhook_keys [1]
-
-  #
-  #Print the message to the log
-  #
-  #puts JSON.pretty_generate(webhook_payload)
-  #puts '--------------------------------------------------------------'
-
-  case webhook_object.downcase
-    when 'repository'
-      repository_webhook(webhook_action, webhook_object, webhook_payload)
-    else
-      puts "[INFO] Ignoring object = #{webhook_object}, action = #{webhook_action}"
-  end
-
-end
-
-#force puts to show in docker logs (reference: sinatra/sinatra#1118 )
+# Force puts to show up in docker logs (reference: sinatra/sinatra#1118, issue #6).
 $stdout.sync = true
 
-#check for required file with your API tocken
-if(!File.exist?('.webhook_properties'))
-  puts '[ERROR] You must have a java style properties file .webhook_properties with githubToken=xx defined.'
-  exit(1)
+require 'optparse'
+
+require_relative 'lib/github_webhooks/app'
+
+# Sinatra's classic mode parses -o/-p out of ARGV for you. Sinatra::Base does
+# not, and both the Dockerfile CMD and the README pass `-o 0.0.0.0` -- without
+# this the server would silently bind to localhost and the container would be
+# unreachable from outside.
+options = { bind: '127.0.0.1', port: 4567, environment: nil }
+OptionParser.new do |opts|
+  opts.banner = 'usage: ruby github_webhooks.rb [options]'
+  opts.on('-o ADDR', '--bind ADDR', 'address to bind to (default 127.0.0.1)') { |v| options[:bind] = v }
+  opts.on('-p PORT', '--port PORT', Integer, 'port to listen on (default 4567)') { |v| options[:port] = v }
+  opts.on('-e ENV', '--environment ENV', 'Sinatra environment') { |v| options[:environment] = v }
+  opts.on('-h', '--help', 'show this message') do
+    puts opts
+    exit 0
+  end
+end.parse!(ARGV)
+
+begin
+  settings = GithubWebhooks::Settings.load
+rescue GithubWebhooks::ConfigurationError => e
+  # Fatal at boot is fine and intentional -- unlike the old code, which called
+  # exit(1) from inside the request path.
+  warn "[ERROR] #{e.message}"
+  exit 1
 end
 
-##################################################################################################
+app = GithubWebhooks::App
+app.configure!(settings)
+app.set :bind, options[:bind]
+app.set :port, options[:port]
+app.set :environment, options[:environment].to_sym if options[:environment]
+app.run!

--- a/lib/github_webhooks/app.rb
+++ b/lib/github_webhooks/app.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'sinatra/base'
+
+require_relative 'errors'
+require_relative 'github_client'
+require_relative 'log'
+require_relative 'repository_defaults'
+require_relative 'settings'
+
+module GithubWebhooks
+  class App < Sinatra::Base
+    # GitHub gives a webhook 10 seconds to respond and records anything slower as
+    # a failed delivery. Repository setup takes longer than that -- it has to wait
+    # for the new repo to be initialized before branch protection will apply -- so
+    # the request is acknowledged immediately and the work runs off-thread.
+    #
+    # The tradeoff: in-flight work is lost if the process restarts. That is
+    # strictly better than the previous behavior, where a sleep(30) in the handler
+    # guaranteed every delivery timed out.
+    DEFAULT_EXECUTOR = ->(job) { Thread.new { job.call } }
+
+    # Synchronous alternative, used by the specs.
+    INLINE_EXECUTOR = ->(job) { job.call }
+
+    # Deliberately plain class accessors rather than Sinatra's `set`: `set` treats
+    # a Proc value as a lazily-computed setting and invokes it on read, so an
+    # executor lambda stored that way gets called with no arguments.
+    class << self
+      attr_accessor :executor, :repository_handler
+    end
+
+    self.executor = DEFAULT_EXECUTOR
+    self.repository_handler = nil
+
+    # Errors are logged and converted to a status code; never leak a stack trace
+    # to a webhook sender, and never let one escape to Puma.
+    set :show_exceptions, false
+    set :raise_errors, false
+
+    # Wires up the real GitHub client. Specs inject a double instead.
+    def self.configure!(settings, executor: DEFAULT_EXECUTOR)
+      client = GithubClient.new(token: settings.github_token)
+      self.repository_handler = RepositoryDefaults.new(client: client)
+      self.executor = executor
+      self
+    end
+
+    post '/github_webhook' do
+      payload = parse_payload
+      # The event name comes from the X-GitHub-Event header, which is what GitHub
+      # actually documents. The old code read payload.keys[1], so it depended on
+      # JSON key ordering and misrouted whenever GitHub reordered the payload.
+      event = request.env['HTTP_X_GITHUB_EVENT'].to_s
+      action = payload['action'].to_s
+
+      unless handled?(event, action)
+        Log.info("Ignoring object = #{event.empty? ? 'unknown' : event}, action = #{action}")
+        status 200
+        return ''
+      end
+
+      process_later(event, action, payload)
+      status 202
+      ''
+    end
+
+    private
+
+    def handled?(event, action)
+      event == 'repository' && action == 'created'
+    end
+
+    def parse_payload
+      body = request.body.read
+      parsed = JSON.parse(body.to_s)
+      halt 400, 'expected a JSON object' unless parsed.is_a?(Hash)
+      parsed
+    rescue JSON::ParserError => e
+      Log.error("Rejecting webhook with unparseable JSON body: #{e.message}")
+      halt 400, 'invalid JSON'
+    end
+
+    def process_later(event, action, payload)
+      handler = self.class.repository_handler
+      if handler.nil?
+        Log.error('No repository handler configured; dropping event')
+        return
+      end
+
+      self.class.executor.call(lambda do
+        # An exception raised inside a Thread is silent by default, so every
+        # failure has to be caught and logged here.
+        begin
+          handler.call(payload)
+        rescue ApiError => e
+          Log.error("GitHub API error processing #{event}/#{action}: #{e.message}")
+        rescue StandardError => e
+          Log.error("Unhandled error processing #{event}/#{action}: #{e.class}: #{e.message}")
+        end
+      end)
+    end
+  end
+end

--- a/lib/github_webhooks/errors.rb
+++ b/lib/github_webhooks/errors.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module GithubWebhooks
+  # Base for every error this app raises deliberately.
+  class Error < StandardError; end
+
+  # Raised at boot when .webhook_properties is missing or has no token. Fatal by
+  # design -- there is nothing useful the server can do without credentials.
+  class ConfigurationError < Error; end
+
+  # Raised when the GitHub API answers with an unexpected status.
+  #
+  # Handled per request and never fatal. The previous implementation called
+  # exit(1) on any API failure, from inside the request path, which took the
+  # whole Puma process down mid-webhook.
+  class ApiError < Error
+    attr_reader :code, :body, :url
+
+    def initialize(message, code: nil, body: nil, url: nil)
+      super(message)
+      @code = code
+      @body = body
+      @url = url
+    end
+  end
+end

--- a/lib/github_webhooks/github_client.rb
+++ b/lib/github_webhooks/github_client.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'uri'
+
+require_relative 'errors'
+require_relative 'log'
+
+module GithubWebhooks
+  # Thin Net::HTTP wrapper around the GitHub REST API.
+  #
+  # Unexpected statuses raise ApiError. They used to call exit(1), which killed
+  # the server; callers that legitimately expect a failure (probing whether a
+  # README exists, say) pass allow_failure: true and inspect the code.
+  class GithubClient
+    API_ROOT = 'https://api.github.com/'
+
+    # Required for the branch-protection endpoints; sent on every request, as
+    # the original did.
+    PREVIEW_ACCEPT = 'application/vnd.github.luke-cage-preview+json'
+
+    REQUEST_CLASSES = {
+      get: Net::HTTP::Get,
+      patch: Net::HTTP::Patch,
+      post: Net::HTTP::Post,
+      put: Net::HTTP::Put
+    }.freeze
+
+    Response = Struct.new(:code, :body, keyword_init: true) do
+      def json
+        JSON.parse(body.to_s)
+      end
+    end
+
+    def initialize(token:, api_root: API_ROOT)
+      @token = token
+      @api_root = api_root
+    end
+
+    def get(path, expect: '200', allow_failure: false, message: nil)
+      request(:get, path, expect: expect, allow_failure: allow_failure, message: message)
+    end
+
+    def patch(path, body, expect: '200', allow_failure: false, message: nil)
+      request(:patch, path, body: body, expect: expect, allow_failure: allow_failure, message: message)
+    end
+
+    def post(path, body, expect: '201', allow_failure: false, message: nil)
+      request(:post, path, body: body, expect: expect, allow_failure: allow_failure, message: message)
+    end
+
+    def put(path, body, expect: '200', allow_failure: false, message: nil)
+      request(:put, path, body: body, expect: expect, allow_failure: allow_failure, message: message)
+    end
+
+    private
+
+    def request(method, path, body: nil, expect: '200', allow_failure: false, message: nil)
+      request_class = REQUEST_CLASSES.fetch(method) do
+        raise ArgumentError, "unknown method: #{method}"
+      end
+
+      url = @api_root + path
+      Log.info("#{message || 'GitHub API'}:  method= #{method.to_s.capitalize}, url= #{url}")
+
+      uri = URI(url)
+      net_request = build_request(request_class, uri, body)
+      raw = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        http.request(net_request)
+      end
+
+      response = Response.new(code: raw.code, body: raw.body)
+      return response if allow_failure || response.code == expect
+
+      raise ApiError.new(
+        "GitHub API returned #{response.code} (expected #{expect}) for #{method.to_s.upcase} #{url}",
+        code: response.code, body: response.body, url: url
+      )
+    end
+
+    def build_request(request_class, uri, body)
+      request = request_class.new(uri)
+      request['Authorization'] = "token #{@token}"
+      request['Content-Type'] = 'application/json'
+      request['Accept'] = PREVIEW_ACCEPT
+      request.body = body unless body.nil?
+      request
+    end
+  end
+end

--- a/lib/github_webhooks/log.rb
+++ b/lib/github_webhooks/log.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module GithubWebhooks
+  # Deliberately minimal. The "[INFO] ..." / "[ERROR] ..." shapes are what
+  # operators grep for in `docker logs`, and script/smoke_test.sh asserts on
+  # them, so they are kept exactly as they were. $stdout.sync is set by the
+  # entry point -- without it these never reach docker logs (issue #6).
+  module Log
+    class << self
+      # Redirectable so specs can capture output instead of spraying it through
+      # the test run.
+      attr_writer :out
+
+      def out
+        @out ||= $stdout
+      end
+
+      def info(message)
+        write('INFO', message)
+      end
+
+      def warn(message)
+        write('WARN', message)
+      end
+
+      def error(message)
+        write('ERROR', message)
+      end
+
+      private
+
+      def write(level, message)
+        out.puts("[#{level}] #{message}")
+      end
+    end
+  end
+end

--- a/lib/github_webhooks/repository_defaults.rb
+++ b/lib/github_webhooks/repository_defaults.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'json'
+
+require_relative 'errors'
+require_relative 'github_client'
+require_relative 'log'
+
+module GithubWebhooks
+  # Applies the default settings to a newly created repository: make sure it has
+  # a README (branch protection cannot apply to an empty repo -- issue #2),
+  # apply the repository settings, protect the default branch, and open an issue
+  # recording what was done.
+  class RepositoryDefaults
+    REPO_CONFIG_FILE = 'new_repo_config.json'
+    # Filename kept as-is: the README documents it and users override the config
+    # directory by volume mount, so renaming it would silently break them.
+    BRANCH_CONFIG_FILE = 'new_master_branch_config.json'
+
+    FALLBACK_BRANCH = 'main'
+
+    def initialize(client:, config_dir: 'config', poll_attempts: 10, poll_interval: 3)
+      @client = client
+      @config_dir = config_dir
+      @poll_attempts = poll_attempts
+      @poll_interval = poll_interval
+    end
+
+    def call(payload)
+      repository = payload['repository'] || {}
+      full_name = repository['full_name']
+      raise ArgumentError, 'payload has no repository.full_name' if full_name.nil?
+
+      branch = default_branch(repository, full_name)
+      Log.info("Processing repository= #{full_name}, default_branch= #{branch}, " \
+               "sender= #{payload.dig('sender', 'login')}")
+
+      author = authorized_user
+      ensure_readme(full_name, author)
+      apply_repository_settings(full_name)
+      protect_branch(full_name, branch)
+      open_summary_issue(full_name, branch, author)
+    end
+
+    private
+
+    # GitHub sends default_branch in the repository payload, so in the normal
+    # case no extra call is needed. The old code hardcoded "master", which 404s
+    # on any repository created since GitHub changed the default to "main".
+    def default_branch(repository, full_name)
+      from_payload = repository['default_branch']
+      return from_payload unless from_payload.to_s.empty?
+
+      response = @client.get("repos/#{full_name}", allow_failure: true,
+                                                   message: 'Looking up default branch')
+      return FALLBACK_BRANCH unless response.code == '200'
+
+      branch = response.json['default_branch']
+      branch.to_s.empty? ? FALLBACK_BRANCH : branch
+    end
+
+    def authorized_user
+      user = @client.get('user', message: 'Getting Authorized User').json
+
+      if user['email'].to_s.empty?
+        # Only used as the README commit author. GitHub falls back to the
+        # authenticated user's default identity, so this is not worth failing
+        # over -- it used to exit(1) and take the server with it.
+        Log.warn("Primary email address is not public for user_login=#{user['login']}; " \
+                 'GitHub will pick the default commit identity')
+      end
+
+      user
+    end
+
+    def ensure_readme(full_name, author)
+      return if readme_exists?(full_name)
+
+      @client.put(
+        "repos/#{full_name}/contents/README.md",
+        readme_body(full_name, author),
+        expect: '201',
+        message: 'Creating README.md (repository must be initialized for the ' \
+                 'branch protection API to work)'
+      )
+
+      # Creating a file is not instantly visible to the branch-protection API.
+      wait_for_readme(full_name)
+    end
+
+    def readme_exists?(full_name)
+      response = @client.get("repos/#{full_name}/contents/README.md",
+                             allow_failure: true,
+                             message: 'Checking existence of README.md')
+      response.code == '200'
+    end
+
+    # Replaces a flat sleep(30). That exceeded GitHub's 10 second webhook
+    # delivery timeout, so every delivery was recorded as failed; the work now
+    # runs off the request thread and polls only as long as it actually needs to.
+    def wait_for_readme(full_name)
+      @poll_attempts.times do |attempt|
+        return true if readme_exists?(full_name)
+
+        Log.info("Waiting for README.md to become visible (attempt #{attempt + 1}/#{@poll_attempts})")
+        sleep(@poll_interval) if @poll_interval.positive?
+      end
+
+      Log.warn("README.md still not visible after #{@poll_attempts} attempts; " \
+               'continuing -- branch protection may fail')
+      false
+    end
+
+    def readme_body(full_name, author)
+      body = {
+        'message' => 'my commit message',
+        'content' => Base64.strict_encode64("# #{full_name}")
+      }
+
+      # The original sent this under a "sender_login" key, which the contents API
+      # ignores, and put the user's *name* in the email field.
+      unless author['email'].to_s.empty?
+        body['committer'] = { 'name' => author['name'], 'email' => author['email'] }
+      end
+
+      JSON.generate(body)
+    end
+
+    def apply_repository_settings(full_name)
+      @client.patch("repos/#{full_name}", read_config(REPO_CONFIG_FILE),
+                    message: 'Defaulting Repository Settings')
+    end
+
+    def protect_branch(full_name, branch)
+      @client.put("repos/#{full_name}/branches/#{branch}/protection",
+                  read_config(BRANCH_CONFIG_FILE),
+                  message: "Protecting #{branch} branch")
+    end
+
+    def open_summary_issue(full_name, branch, author)
+      # Built with JSON.generate: the original interpolated these values straight
+      # into a JSON string, so any name containing a quote produced invalid JSON.
+      body = JSON.generate(
+        'title' => "Ran webhook to default repository settings & protected the #{branch} branch",
+        'body' => " @#{author['login']} set default repository settings and " \
+                  "protected the #{branch} branch."
+      )
+
+      @client.post("repos/#{full_name}/issues", body, expect: '201',
+                                                      message: 'Recording changes in an issue')
+    end
+
+    def read_config(filename)
+      path = File.join(@config_dir, filename)
+      raise ConfigurationError, "#{path} file missing" unless File.exist?(path)
+
+      File.read(path)
+    end
+  end
+end

--- a/lib/github_webhooks/settings.rb
+++ b/lib/github_webhooks/settings.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'java-properties'
+
+require_relative 'errors'
+
+module GithubWebhooks
+  # Loads .webhook_properties once at boot.
+  #
+  # The previous implementation re-read and re-parsed this file on every single
+  # API call, and called exit(1) from inside the request path if it had gone
+  # missing.
+  class Settings
+    DEFAULT_PATH = '.webhook_properties'
+
+    attr_reader :github_token
+
+    def self.load(path = DEFAULT_PATH)
+      unless File.exist?(path)
+        raise ConfigurationError,
+              "You must have a java style properties file #{path} with githubToken=xx defined"
+      end
+
+      new(JavaProperties.load(path))
+    end
+
+    def initialize(properties)
+      @github_token = presence(properties[:githubToken])
+
+      return unless @github_token.nil?
+
+      raise ConfigurationError, 'githubToken is missing or empty in the properties file'
+    end
+
+    private
+
+    def presence(value)
+      string = value.to_s.strip
+      string.empty? ? nil : string
+    end
+  end
+end

--- a/script/smoke_test.sh
+++ b/script/smoke_test.sh
@@ -55,6 +55,33 @@ check "POST /github_webhook (repository/deleted)" 200 \
 
 check "GET /nope (unknown route)" 404 "$(get /nope)"
 
+check "POST /github_webhook (malformed JSON)" 400 \
+  "$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/github_webhook" \
+      -H 'Content-Type: application/json' -H 'X-GitHub-Event: repository' \
+      -d 'not json')"
+
+# An event we DO act on. The container runs with a dummy token, so the GitHub
+# call behind this fails -- which is the point. The work is acknowledged with 202
+# and runs off the request thread, and the failure must be logged and contained.
+# This is the regression test for exit(1) in the request path, which used to take
+# the whole server down mid-webhook.
+check "POST /github_webhook (repository/created)" 202 \
+  "$(post repository '{"action":"created","repository":{"full_name":"acme/demo","default_branch":"main"},"sender":{"login":"acme-bot"}}')"
+
+# Give the background thread a moment to fail and log.
+sleep 3
+
+check "server still serving after a failed background job" 404 "$(get /nope)"
+
+if [ -n "$CONTAINER" ]; then
+  if logs | grep -qE '\[ERROR\].*processing repository/created'; then
+    echo "ok    background failure was logged, not fatal"
+  else
+    echo "FAIL  expected a logged [ERROR] for the failed repository/created job"
+    failures=$((failures + 1))
+  fi
+fi
+
 # $stdout.sync must keep working or docker logs go silent -- see issue #6.
 if [ -n "$CONTAINER" ]; then
   if logs | grep -q '\[INFO\] Ignoring object'; then

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+# Records what it was handed instead of calling GitHub.
+class RecordingHandler
+  attr_reader :payloads
+
+  def initialize(&raiser)
+    @payloads = []
+    @raiser = raiser
+  end
+
+  def call(payload)
+    @payloads << payload
+    @raiser&.call
+  end
+end
+
+class AppSpec < SpecCase
+  include Rack::Test::Methods
+
+  def app
+    GithubWebhooks::App
+  end
+
+  def setup
+    super
+    @handler = RecordingHandler.new
+    install_handler(@handler)
+  end
+
+  def install_handler(handler)
+    GithubWebhooks::App.repository_handler = handler
+    # Run the job on this thread so assertions see its effects.
+    GithubWebhooks::App.executor = GithubWebhooks::App::INLINE_EXECUTOR
+  end
+
+  def deliver(event, payload)
+    post '/github_webhook', JSON.generate(payload),
+         'CONTENT_TYPE' => 'application/json',
+         'HTTP_X_GITHUB_EVENT' => event
+  end
+
+  def test_acknowledges_repository_created_with_202_and_runs_the_handler
+    deliver('repository', 'action' => 'created',
+                          'repository' => { 'full_name' => 'acme/demo', 'default_branch' => 'main' })
+
+    assert_equal 202, last_response.status
+    assert_equal 1, @handler.payloads.length
+    assert_equal 'acme/demo', @handler.payloads.first.dig('repository', 'full_name')
+  end
+
+  def test_ignores_repository_actions_other_than_created
+    deliver('repository', 'action' => 'deleted', 'repository' => { 'full_name' => 'acme/demo' })
+
+    assert_equal 200, last_response.status
+    assert_empty @handler.payloads
+    assert_logged(/\[INFO\] Ignoring object = repository, action = deleted/)
+  end
+
+  def test_ignores_events_it_does_not_handle
+    deliver('organization', 'action' => 'created', 'organization' => { 'login' => 'acme' })
+
+    assert_equal 200, last_response.status
+    assert_empty @handler.payloads
+    assert_logged(/\[INFO\] Ignoring object = organization, action = created/)
+  end
+
+  # The old code took the event name from payload.keys[1], so a payload whose
+  # second key happened to be "repository" was treated as a repository event no
+  # matter what GitHub actually sent.
+  def test_dispatches_on_the_header_not_on_json_key_order
+    deliver('organization', 'action' => 'created',
+                            'repository' => { 'full_name' => 'acme/demo' },
+                            'organization' => { 'login' => 'acme' })
+
+    assert_equal 200, last_response.status
+    assert_empty @handler.payloads, 'must not dispatch on payload key ordering'
+  end
+
+  def test_missing_event_header_is_ignored_rather_than_crashing
+    post '/github_webhook', JSON.generate('action' => 'created'),
+         'CONTENT_TYPE' => 'application/json'
+
+    assert_equal 200, last_response.status
+    assert_logged(/Ignoring object = unknown/)
+  end
+
+  def test_rejects_unparseable_json
+    post '/github_webhook', 'not json at all', 'CONTENT_TYPE' => 'application/json',
+                                               'HTTP_X_GITHUB_EVENT' => 'repository'
+
+    assert_equal 400, last_response.status
+    assert_empty @handler.payloads
+    assert_logged(/unparseable JSON/)
+  end
+
+  def test_rejects_a_json_body_that_is_not_an_object
+    post '/github_webhook', '["a","b"]', 'CONTENT_TYPE' => 'application/json',
+                                         'HTTP_X_GITHUB_EVENT' => 'repository'
+
+    assert_equal 400, last_response.status
+  end
+
+  # Regression test for the exit(1)-in-the-request-path bug: a failing GitHub
+  # call used to terminate the whole Puma process. It must now be logged and
+  # contained.
+  def test_a_failing_handler_does_not_escape_or_change_the_response
+    install_handler(RecordingHandler.new do
+      raise GithubWebhooks::ApiError.new('boom', code: '401', url: 'https://api.github.com/user')
+    end)
+
+    deliver('repository', 'action' => 'created', 'repository' => { 'full_name' => 'acme/demo' })
+
+    assert_equal 202, last_response.status
+    assert_logged(/\[ERROR\] GitHub API error processing repository\/created: boom/)
+  end
+
+  def test_an_unexpected_handler_error_is_also_contained
+    install_handler(RecordingHandler.new { raise 'totally unexpected' })
+
+    deliver('repository', 'action' => 'created', 'repository' => { 'full_name' => 'acme/demo' })
+
+    assert_equal 202, last_response.status
+    assert_logged(/\[ERROR\] Unhandled error processing repository\/created: RuntimeError/)
+  end
+
+  def test_unknown_routes_are_404
+    get '/nope'
+
+    assert_equal 404, last_response.status
+  end
+end

--- a/spec/github_client_spec.rb
+++ b/spec/github_client_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+class GithubClientSpec < SpecCase
+  def setup
+    super
+    @client = GithubWebhooks::GithubClient.new(token: 'test-token')
+  end
+
+  def test_sends_the_documented_auth_and_accept_headers
+    stub = stub_request(:get, 'https://api.github.com/user')
+           .with(headers: {
+                   'Authorization' => 'token test-token',
+                   'Content-Type' => 'application/json',
+                   'Accept' => GithubWebhooks::GithubClient::PREVIEW_ACCEPT
+                 })
+           .to_return(status: 200, body: '{"login":"jimzucker"}')
+
+    assert_equal 'jimzucker', @client.get('user').json['login']
+    assert_requested stub
+  end
+
+  def test_raises_api_error_on_an_unexpected_status
+    stub_request(:get, 'https://api.github.com/user')
+      .to_return(status: 401, body: '{"message":"Bad credentials"}')
+
+    error = assert_raises(GithubWebhooks::ApiError) { @client.get('user') }
+
+    assert_equal '401', error.code
+    assert_match(/returned 401 \(expected 200\)/, error.message)
+    assert_match(/Bad credentials/, error.body)
+  end
+
+  # Callers that legitimately probe for a 404 (does this README exist?) must be
+  # able to do so without an exception.
+  def test_allow_failure_returns_the_response_instead_of_raising
+    stub_request(:get, 'https://api.github.com/repos/acme/demo/contents/README.md')
+      .to_return(status: 404, body: '{}')
+
+    response = @client.get('repos/acme/demo/contents/README.md', allow_failure: true)
+
+    assert_equal '404', response.code
+  end
+
+  def test_put_sends_the_body_through_unchanged
+    stub = stub_request(:put, 'https://api.github.com/repos/acme/demo/contents/README.md')
+           .with(body: '{"message":"hi"}')
+           .to_return(status: 201, body: '{}')
+
+    @client.put('repos/acme/demo/contents/README.md', '{"message":"hi"}', expect: '201')
+
+    assert_requested stub
+  end
+
+  def test_rejects_an_unsupported_http_method
+    assert_raises(ArgumentError) { @client.send(:request, :delete, 'user') }
+  end
+
+  def test_logs_the_call_without_leaking_the_token
+    stub_request(:get, 'https://api.github.com/user').to_return(status: 200, body: '{}')
+
+    @client.get('user', message: 'Getting Authorized User')
+
+    assert_logged(%r{\[INFO\] Getting Authorized User:\s+method= Get, url= https://api\.github\.com/user})
+    refute_logged(/test-token/)
+  end
+end

--- a/spec/repository_defaults_spec.rb
+++ b/spec/repository_defaults_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+class RepositoryDefaultsSpec < SpecCase
+  USER_JSON = '{"login":"jimzucker","name":"Jim Zucker","email":"jim@example.com"}'
+
+  def setup
+    super
+    @client = GithubWebhooks::GithubClient.new(token: 'test-token')
+    # poll_interval: 0 keeps the README wait from actually sleeping.
+    @defaults = GithubWebhooks::RepositoryDefaults.new(
+      client: @client, config_dir: 'config', poll_attempts: 3, poll_interval: 0
+    )
+  end
+
+  def stub_user(body: USER_JSON)
+    stub_request(:get, 'https://api.github.com/user').to_return(status: 200, body: body)
+  end
+
+  def stub_readme_present(full_name = 'acme/demo')
+    stub_request(:get, "https://api.github.com/repos/#{full_name}/contents/README.md")
+      .to_return(status: 200, body: '{}')
+  end
+
+  def stub_settings_and_issue(full_name = 'acme/demo')
+    stub_request(:patch, "https://api.github.com/repos/#{full_name}").to_return(status: 200, body: '{}')
+    stub_request(:post, "https://api.github.com/repos/#{full_name}/issues")
+      .to_return(status: 201, body: '{}')
+  end
+
+  def payload(repository)
+    { 'action' => 'created', 'repository' => repository, 'sender' => { 'login' => 'jimzucker' } }
+  end
+
+  # Stubs a request and returns an array that collects the bodies sent to it, so
+  # assertions can run after the call rather than inside a webmock matcher.
+  def capture_bodies(method, url, status:, body: '{}')
+    captured = []
+    stub_request(method, url)
+      .with { |request| captured << request.body; true }
+      .to_return(status: status, body: body)
+    captured
+  end
+
+  # The old code hardcoded branches/master/protection, which 404s on any repo
+  # created since GitHub switched the default to main.
+  def test_protects_the_default_branch_from_the_payload
+    stub_user
+    stub_readme_present
+    stub_settings_and_issue
+    protect = stub_request(:put, 'https://api.github.com/repos/acme/demo/branches/main/protection')
+              .to_return(status: 200, body: '{}')
+
+    @defaults.call(payload('full_name' => 'acme/demo', 'default_branch' => 'main'))
+
+    assert_requested protect
+  end
+
+  def test_still_works_for_repositories_whose_default_branch_is_master
+    stub_user
+    stub_readme_present
+    stub_settings_and_issue
+    protect = stub_request(:put, 'https://api.github.com/repos/acme/demo/branches/master/protection')
+              .to_return(status: 200, body: '{}')
+
+    @defaults.call(payload('full_name' => 'acme/demo', 'default_branch' => 'master'))
+
+    assert_requested protect
+  end
+
+  def test_looks_up_the_default_branch_when_the_payload_omits_it
+    stub_user
+    stub_readme_present
+    stub_settings_and_issue
+    lookup = stub_request(:get, 'https://api.github.com/repos/acme/demo')
+             .to_return(status: 200, body: '{"default_branch":"trunk"}')
+    protect = stub_request(:put, 'https://api.github.com/repos/acme/demo/branches/trunk/protection')
+              .to_return(status: 200, body: '{}')
+
+    @defaults.call(payload('full_name' => 'acme/demo'))
+
+    assert_requested lookup
+    assert_requested protect
+  end
+
+  def test_falls_back_to_main_when_the_branch_cannot_be_determined
+    stub_user
+    stub_readme_present
+    stub_settings_and_issue
+    stub_request(:get, 'https://api.github.com/repos/acme/demo').to_return(status: 404, body: '{}')
+    protect = stub_request(:put, 'https://api.github.com/repos/acme/demo/branches/main/protection')
+              .to_return(status: 200, body: '{}')
+
+    @defaults.call(payload('full_name' => 'acme/demo'))
+
+    assert_requested protect
+  end
+
+  # The original sent the committer under a "sender_login" key the contents API
+  # ignores, and put the user's *name* in the email field.
+  def test_creates_a_readme_with_a_correctly_shaped_committer
+    stub_user
+    stub_request(:get, 'https://api.github.com/repos/acme/demo/contents/README.md')
+      .to_return({ status: 404, body: '{}' }, { status: 200, body: '{}' })
+    stub_settings_and_issue
+    stub_request(:put, 'https://api.github.com/repos/acme/demo/branches/main/protection')
+      .to_return(status: 200, body: '{}')
+    created = capture_bodies(:put, 'https://api.github.com/repos/acme/demo/contents/README.md',
+                             status: 201)
+
+    @defaults.call(payload('full_name' => 'acme/demo', 'default_branch' => 'main'))
+
+    body = JSON.parse(created.last)
+    assert_equal 'Jim Zucker', body.dig('committer', 'name')
+    assert_equal 'jim@example.com', body.dig('committer', 'email')
+    assert_nil body['sender_login'], 'sender_login is not a key the contents API understands'
+    assert_equal '# acme/demo', Base64.strict_decode64(body['content'])
+  end
+
+  def test_omits_the_committer_and_warns_when_the_primary_email_is_private
+    stub_user(body: '{"login":"jimzucker","name":"Jim Zucker","email":null}')
+    stub_request(:get, 'https://api.github.com/repos/acme/demo/contents/README.md')
+      .to_return({ status: 404, body: '{}' }, { status: 200, body: '{}' })
+    stub_settings_and_issue
+    stub_request(:put, 'https://api.github.com/repos/acme/demo/branches/main/protection')
+      .to_return(status: 200, body: '{}')
+    created = capture_bodies(:put, 'https://api.github.com/repos/acme/demo/contents/README.md',
+                             status: 201)
+
+    # Used to exit(1) and take the server down.
+    @defaults.call(payload('full_name' => 'acme/demo', 'default_branch' => 'main'))
+
+    assert_nil JSON.parse(created.last)['committer']
+    assert_logged(/\[WARN\] Primary email address is not public/)
+  end
+
+  # The original interpolated these straight into a JSON string literal.
+  def test_generates_valid_json_when_values_contain_quotes
+    stub_user(body: JSON.generate('login' => 'jim"z', 'name' => 'Jim "JZ" Zucker',
+                                  'email' => 'jim@example.com'))
+    stub_readme_present
+    stub_request(:patch, 'https://api.github.com/repos/acme/demo').to_return(status: 200, body: '{}')
+    stub_request(:put, 'https://api.github.com/repos/acme/demo/branches/main/protection')
+      .to_return(status: 200, body: '{}')
+    issues = capture_bodies(:post, 'https://api.github.com/repos/acme/demo/issues', status: 201)
+
+    @defaults.call(payload('full_name' => 'acme/demo', 'default_branch' => 'main'))
+
+    body = JSON.parse(issues.last) # would raise on the old interpolated string
+    assert_includes body['body'], 'jim"z'
+    assert_includes body['title'], 'main'
+  end
+
+  def test_reports_the_branch_name_in_the_summary_issue
+    stub_user
+    stub_readme_present
+    stub_request(:patch, 'https://api.github.com/repos/acme/demo').to_return(status: 200, body: '{}')
+    stub_request(:put, 'https://api.github.com/repos/acme/demo/branches/trunk/protection')
+      .to_return(status: 200, body: '{}')
+    issues = capture_bodies(:post, 'https://api.github.com/repos/acme/demo/issues', status: 201)
+
+    @defaults.call(payload('full_name' => 'acme/demo', 'default_branch' => 'trunk'))
+
+    assert_includes JSON.parse(issues.last)['body'], 'protected the trunk branch'
+  end
+
+  def test_raises_when_the_payload_has_no_repository
+    assert_raises(ArgumentError) { @defaults.call('action' => 'created') }
+  end
+
+  def test_propagates_api_errors_so_the_caller_can_log_them
+    stub_request(:get, 'https://api.github.com/user').to_return(status: 401, body: '{}')
+
+    assert_raises(GithubWebhooks::ApiError) do
+      @defaults.call(payload('full_name' => 'acme/demo', 'default_branch' => 'main'))
+    end
+  end
+end

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'tempfile'
+
+require_relative 'spec_helper'
+
+class SettingsSpec < SpecCase
+  def with_properties(contents)
+    Tempfile.create('webhook_properties') do |file|
+      file.write(contents)
+      file.flush
+      yield file.path
+    end
+  end
+
+  def test_loads_the_github_token
+    with_properties("githubToken=abc123\n") do |path|
+      assert_equal 'abc123', GithubWebhooks::Settings.load(path).github_token
+    end
+  end
+
+  def test_raises_when_the_file_is_missing
+    error = assert_raises(GithubWebhooks::ConfigurationError) do
+      GithubWebhooks::Settings.load('/nonexistent/.webhook_properties')
+    end
+
+    assert_match(/java style properties file/, error.message)
+  end
+
+  def test_raises_when_the_token_is_absent
+    with_properties("somethingElse=x\n") do |path|
+      assert_raises(GithubWebhooks::ConfigurationError) { GithubWebhooks::Settings.load(path) }
+    end
+  end
+
+  def test_raises_when_the_token_is_blank
+    with_properties("githubToken=   \n") do |path|
+      assert_raises(GithubWebhooks::ConfigurationError) { GithubWebhooks::Settings.load(path) }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+ENV['RACK_ENV'] = 'test'
+
+require 'stringio'
+
+require 'minitest/autorun'
+require 'rack/test'
+require 'webmock/minitest'
+
+require_relative '../lib/github_webhooks/app'
+
+module LogCapture
+  def setup
+    super
+    @log_output = StringIO.new
+    GithubWebhooks::Log.out = @log_output
+  end
+
+  def teardown
+    GithubWebhooks::Log.out = $stdout
+    super
+  end
+
+  def log_text
+    @log_output.string
+  end
+
+  def assert_logged(pattern, message = nil)
+    assert_match pattern, log_text, message || "expected #{pattern.inspect} in the log output"
+  end
+
+  def refute_logged(pattern, message = nil)
+    refute_match pattern, log_text, message || "did not expect #{pattern.inspect} in the log output"
+  end
+end
+
+class SpecCase < Minitest::Test
+  include LogCapture
+
+  # Minitest::Test treats any subclass with no test_ methods as fine, but this
+  # base class itself should never be collected as a suite.
+  def self.runnable_methods
+    self == SpecCase ? [] : super
+  end
+end


### PR DESCRIPTION
`github_webhooks.rb` could not be loaded without booting a server or calling `exit(1)`, so none of it was testable and every bug below was found by reading rather than by running. This splits it into `lib/github_webhooks/` (modular Sinatra) and adds a Minitest + rack-test suite covering each fix.

`github_webhooks.rb` remains the entry point, so the Dockerfile `CMD` and the documented `ruby github_webhooks.rb` both keep working.

## Bugs fixed

| Was | Effect | Now |
| --- | --- | --- |
| `exit(1)` inside the request path (6 call sites) | **One GitHub API error killed the whole Puma process mid-webhook** | Raises `ApiError`, logged and contained |
| `sleep(30)` in the handler | Exceeds GitHub's 10s delivery timeout, so *every* delivery was recorded as failed | `202` immediately, work runs off-thread, polls only as long as needed |
| `branches/master/protection` hardcoded | 404s on any repo created since `main` became the default | Reads `repository.default_branch`, with lookup + `main` fallback |
| `webhook_object = payload.keys[1]` | Misroutes whenever GitHub reorders payload keys | Reads the `X-GitHub-Event` header, as documented |
| `authorized_user_response` never defined | `NameError` instead of the intended error message | Fixed; and a private primary email is now a **warning**, not fatal — it only feeds the README commit author |
| Committer sent as `"sender_login"`, with the user's *name* in the `email` field | Contents API ignores the key; malformed author | Correct `committer` `{name, email}`, omitted entirely when no public email |
| Request JSON built by string interpolation | Any name or repo containing `"` produced invalid JSON | `JSON.generate` |
| `.webhook_properties` re-read and re-parsed on every API call | Repeated disk I/O; `exit(1)` mid-request if it vanished | Loaded once at boot and validated |

Also: a malformed body now returns **400** instead of a 500 from an uncaught `JSON::ParserError`.

> [!NOTE]
> `Sinatra::Base` does not parse `ARGV` the way classic mode does. The Dockerfile passes `-o 0.0.0.0`, so the entry point now parses `-o`/`-p` itself — without that the container would have silently bound to localhost and been unreachable. Confirmed in the smoke test via `Listening on http://0.0.0.0:4567`.

## Structure

| Path | Purpose |
| --- | --- |
| `github_webhooks.rb` | entry point; parses `-o`/`-p`, starts the server |
| `config.ru` | Rack entry point for `bundle exec rackup` |
| `lib/github_webhooks/app.rb` | routes and event dispatch |
| `lib/github_webhooks/github_client.rb` | GitHub REST calls, raises instead of exiting |
| `lib/github_webhooks/repository_defaults.rb` | the new-repository workflow |
| `lib/github_webhooks/settings.rb` | `.webhook_properties` loading |
| `spec/` | 30 specs |

## Behavior change

`POST /github_webhook` now returns **202** for events it acts on (work in background) and **200** for events it ignores. Because work is in-flight rather than queued, a restart loses unfinished setup — documented in the README. That is strictly better than the previous state, where the `sleep(30)` guaranteed *every* delivery timed out.

## Verification

- **30 specs, 73 assertions, all passing.** New `Specs` CI job runs them on every PR.
- Smoke test extended with the regression that actually matters: a `repository/created` event against a dummy token returns `202`, GitHub answers `401`, and the server **logs it and keeps serving** — `RestartCount=0`, puma still PID 1. Under the old code that call path was `exit(1)`.
- Malformed-JSON → 400 also asserted in the smoke test.
- OSV scan clean across all **25** resolved gems (the four new test gems pull in 7 transitive deps).
- Test gems excluded from the runtime image via `BUNDLE_WITHOUT=test`; image stays at 286 MB.

Two notes on what I deliberately did *not* change: `config/new_master_branch_config.json` keeps its filename, since the README documents it and users override the config directory by volume mount. And `repository_defaults.rb`'s live API path is covered by webmock stubs only — a real end-to-end run needs a token and a throwaway repo.

Next: HMAC signature verification, which is the remaining security gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)