### PR TITLE
Verify X-Hub-Signature-256 on every webhook delivery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,13 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Start container
+        env:
+          WEBHOOK_SECRET: smoke-test-secret
         run: |
-          printf 'githubToken=dummy-token-for-ci\n' > "$RUNNER_TEMP/webhook_properties"
+          {
+            printf 'githubToken=dummy-token-for-ci\n'
+            printf 'webhookSecret=%s\n' "$WEBHOOK_SECRET"
+          } > "$RUNNER_TEMP/webhook_properties"
           docker run -d --name gw-ci -p 4567:4567 \
             -v "$RUNNER_TEMP/webhook_properties:/usr/src/app/.webhook_properties" \
             github-webhooks:ci
@@ -46,7 +51,21 @@ jobs:
           docker logs gw-ci
 
       - name: Smoke test
+        env:
+          WEBHOOK_SECRET: smoke-test-secret
         run: ./script/smoke_test.sh http://127.0.0.1:4567 gw-ci
+
+      # Booting without a secret must fail closed rather than serve an open endpoint.
+      - name: Verify the server refuses to boot without a webhook secret
+        run: |
+          printf 'githubToken=dummy-token-for-ci\n' > "$RUNNER_TEMP/no_secret"
+          if docker run --rm \
+               -v "$RUNNER_TEMP/no_secret:/usr/src/app/.webhook_properties" \
+               github-webhooks:ci; then
+            echo "FAIL: server booted with no webhookSecret configured"
+            exit 1
+          fi
+          echo "ok: server refused to boot without a webhook secret"
 
       - name: Stop container
         if: always()

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The branch is read from `repository.default_branch` in the webhook payload, so t
 | `202` | Accepted; repository setup is running in the background (watch the logs) |
 | `200` | Received, but this is not an event the service acts on |
 | `400` | Body was not a JSON object |
+| `401` | `X-Hub-Signature-256` was missing or did not verify |
 
 Because the work is in-flight rather than queued, a restart loses any setup that had not finished. Check the logs after creating a repository.
 
@@ -36,11 +37,26 @@ You can change the configuration for the settings used by the webhooks.  Each co
 
 # To run the webhooks with default settings
 
-## First create a file .webhook_properties with one property defined
+## First create a file .webhook_properties with two properties defined
 
 ```
 githubToken=<github api token>
+webhookSecret=<shared secret, also set in the webhook's Secret field in GitHub>
 ```
+
+> **Both are required.** The server refuses to start if either is missing.
+>
+> `webhookSecret` must match the **Secret** field of the webhook in GitHub
+> (repository or organization → Settings → Webhooks → your webhook → Secret).
+> Every request is checked against `X-Hub-Signature-256`, and anything that does
+> not verify is rejected with `401` before it is processed. Without this the
+> endpoint would act on a privileged GitHub token for anyone who found the URL.
+>
+> Generate one with:
+>
+> ```
+> openssl rand -hex 32
+> ```
 
 ## Start docker
 
@@ -131,10 +147,11 @@ Requires Ruby 3.4 or newer (see the `Dockerfile` for the version this is built a
    bundle install
    ```
 
-2. Create a file `.webhook_properties` with one entry:
+2. Create a file `.webhook_properties` with both entries (see above):
 
    ```
    githubToken=<github api token>
+   webhookSecret=<shared secret>
    ```
 
 3. Start the server; it listens on port 4567:

--- a/lib/github_webhooks/app.rb
+++ b/lib/github_webhooks/app.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'openssl'
+require 'rack/utils'
 require 'sinatra/base'
 
 require_relative 'errors'
@@ -24,15 +26,27 @@ module GithubWebhooks
     # Synchronous alternative, used by the specs.
     INLINE_EXECUTOR = ->(job) { job.call }
 
+    WEBHOOK_PATH = '/github_webhook'
+
+    # GitHub signs the raw request body with the webhook's shared secret and
+    # sends the result here. See
+    # https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+    #
+    # The legacy X-Hub-Signature (SHA-1) header is deliberately not accepted.
+    SIGNATURE_HEADER = 'HTTP_X_HUB_SIGNATURE_256'
+    SIGNATURE_PREFIX = 'sha256='
+    SIGNATURE_DIGEST = 'sha256'
+
     # Deliberately plain class accessors rather than Sinatra's `set`: `set` treats
     # a Proc value as a lazily-computed setting and invokes it on read, so an
     # executor lambda stored that way gets called with no arguments.
     class << self
-      attr_accessor :executor, :repository_handler
+      attr_accessor :executor, :repository_handler, :webhook_secret
     end
 
     self.executor = DEFAULT_EXECUTOR
     self.repository_handler = nil
+    self.webhook_secret = nil
 
     # Errors are logged and converted to a status code; never leak a stack trace
     # to a webhook sender, and never let one escape to Puma.
@@ -43,11 +57,20 @@ module GithubWebhooks
     def self.configure!(settings, executor: DEFAULT_EXECUTOR)
       client = GithubClient.new(token: settings.github_token)
       self.repository_handler = RepositoryDefaults.new(client: client)
+      self.webhook_secret = settings.webhook_secret
       self.executor = executor
       self
     end
 
-    post '/github_webhook' do
+    # Nothing reaches the handler until the signature checks out. The body is read
+    # here, once, because the signature covers the raw bytes -- re-serializing
+    # parsed JSON would not reproduce them.
+    before WEBHOOK_PATH do
+      @raw_body = request.body.read
+      verify_signature!(@raw_body)
+    end
+
+    post WEBHOOK_PATH do
       payload = parse_payload
       # The event name comes from the X-GitHub-Event header, which is what GitHub
       # actually documents. The old code read payload.keys[1], so it depended on
@@ -72,9 +95,37 @@ module GithubWebhooks
       event == 'repository' && action == 'created'
     end
 
+    # Rejects the request unless X-Hub-Signature-256 matches an HMAC of the raw
+    # body under the shared secret. Without this the endpoint accepted anything
+    # from anyone and acted on it using a privileged GitHub token.
+    def verify_signature!(body)
+      secret = self.class.webhook_secret
+
+      if secret.nil? || secret.empty?
+        # Settings enforces this at boot; this branch exists so the app can never
+        # fail open, whatever configures it.
+        Log.error('No webhook secret configured; refusing the request')
+        halt 500, 'server misconfigured'
+      end
+
+      provided = request.env[SIGNATURE_HEADER].to_s
+      if provided.empty?
+        Log.error('Rejecting webhook with no X-Hub-Signature-256 header')
+        halt 401, 'missing signature'
+      end
+
+      expected = SIGNATURE_PREFIX + OpenSSL::HMAC.hexdigest(SIGNATURE_DIGEST, secret, body.to_s)
+
+      # Constant-time; a plain == leaks how much of the signature was correct.
+      # Never log `expected` -- it is enough to forge the next request.
+      return if Rack::Utils.secure_compare(expected, provided)
+
+      Log.error('Rejecting webhook with an invalid X-Hub-Signature-256')
+      halt 401, 'invalid signature'
+    end
+
     def parse_payload
-      body = request.body.read
-      parsed = JSON.parse(body.to_s)
+      parsed = JSON.parse(@raw_body.to_s)
       halt 400, 'expected a JSON object' unless parsed.is_a?(Hash)
       parsed
     rescue JSON::ParserError => e

--- a/lib/github_webhooks/settings.rb
+++ b/lib/github_webhooks/settings.rb
@@ -13,12 +13,13 @@ module GithubWebhooks
   class Settings
     DEFAULT_PATH = '.webhook_properties'
 
-    attr_reader :github_token
+    attr_reader :github_token, :webhook_secret
 
     def self.load(path = DEFAULT_PATH)
       unless File.exist?(path)
         raise ConfigurationError,
-              "You must have a java style properties file #{path} with githubToken=xx defined"
+              "You must have a java style properties file #{path} with " \
+              'githubToken=xx and webhookSecret=xx defined'
       end
 
       new(JavaProperties.load(path))
@@ -26,10 +27,17 @@ module GithubWebhooks
 
     def initialize(properties)
       @github_token = presence(properties[:githubToken])
+      @webhook_secret = presence(properties[:webhookSecret])
 
-      return unless @github_token.nil?
+      raise ConfigurationError, 'githubToken is missing or empty in the properties file' if @github_token.nil?
+      return unless @webhook_secret.nil?
 
-      raise ConfigurationError, 'githubToken is missing or empty in the properties file'
+      # Fail closed. Without a secret the endpoint would accept anything from
+      # anyone and act on it with a privileged token, which is the whole reason
+      # this check exists.
+      raise ConfigurationError,
+            'webhookSecret is missing or empty in the properties file. Set the same ' \
+            "value here and in the webhook's Secret field in GitHub."
     end
 
     private

--- a/script/smoke_test.sh
+++ b/script/smoke_test.sh
@@ -2,15 +2,18 @@
 # End-to-end smoke test against a running container.
 #
 # Used by .github/workflows/ci.yml and runnable by hand:
-#   ./script/smoke_test.sh http://127.0.0.1:4567 gw-ci
+#   WEBHOOK_SECRET=smoke-test-secret ./script/smoke_test.sh http://127.0.0.1:4567 gw-ci
 #
 # Args:
 #   $1  base URL of the running server (default http://127.0.0.1:4567)
 #   $2  docker container name to pull logs from (optional; enables log assertions)
+# Env:
+#   WEBHOOK_SECRET  must match webhookSecret in the container's .webhook_properties
 set -eu
 
 BASE="${1:-http://127.0.0.1:4567}"
 CONTAINER="${2:-}"
+SECRET="${WEBHOOK_SECRET:-smoke-test-secret}"
 
 failures=0
 
@@ -30,65 +33,98 @@ check() {
   fi
 }
 
+check_log() {
+  label="$1"
+  pattern="$2"
+  [ -n "$CONTAINER" ] || return 0
+  if logs | grep -qE "$pattern"; then
+    echo "ok    $label"
+  else
+    echo "FAIL  $label (no match for /$pattern/ in container logs)"
+    failures=$((failures + 1))
+  fi
+}
+
+# Same HMAC GitHub computes over the raw body; verified to agree with
+# OpenSSL::HMAC.hexdigest in Ruby.
+sign() {
+  printf '%s' "$1" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.*= *//'
+}
+
+# $1 event, $2 body -- correctly signed, the way GitHub sends it.
 post() {
-  curl -s -o /dev/null -w '%{http_code}' \
-    -X POST "$BASE/github_webhook" \
-    -H 'Content-Type: application/json' \
-    -H "X-GitHub-Event: $1" \
-    -d "$2"
+  post_raw "$1" "$2" "X-Hub-Signature-256: sha256=$(sign "$2")"
+}
+
+# $1 event, $2 body, $3 extra header line (may be empty)
+post_raw() {
+  if [ -n "$3" ]; then
+    curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/github_webhook" \
+      -H 'Content-Type: application/json' -H "X-GitHub-Event: $1" -H "$3" -d "$2"
+  else
+    curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/github_webhook" \
+      -H 'Content-Type: application/json' -H "X-GitHub-Event: $1" -d "$2"
+  fi
 }
 
 get() {
   curl -s -o /dev/null -w '%{http_code}' "$BASE$1"
 }
 
+IGNORED='{"action":"created","organization":{"login":"acme"}}'
+REPO_DELETED='{"action":"deleted","repository":{"full_name":"acme/demo","default_branch":"main"}}'
+REPO_CREATED='{"action":"created","repository":{"full_name":"acme/demo","default_branch":"main"},"sender":{"login":"acme-bot"}}'
+
 echo "--- smoke test against $BASE ---"
 
-# An event we do not act on: exercises routing and request.body.read without
-# touching the GitHub API.
-check "POST /github_webhook (non-repository object)" 200 \
-  "$(post organization '{"action":"created","organization":{"login":"acme"}}')"
+# --- signature verification -------------------------------------------------
+# An unsigned request must never reach the handler: the endpoint acts on a
+# privileged GitHub token, so anyone who learns the URL could otherwise drive it.
+check "unsigned request is rejected" 401 "$(post_raw repository "$REPO_CREATED" '')"
 
-# A repository event with an action we ignore: one level deeper, still no API call.
-check "POST /github_webhook (repository/deleted)" 200 \
-  "$(post repository '{"action":"deleted","repository":{"full_name":"acme/demo","default_branch":"main"}}')"
+check "garbage signature is rejected" 401 \
+  "$(post_raw repository "$REPO_CREATED" 'X-Hub-Signature-256: sha256=deadbeef')"
 
+# Signature valid, but for a different body.
+check "tampered body is rejected" 401 \
+  "$(post_raw repository "$(printf '%s' "$REPO_CREATED" | sed 's|acme/demo|attacker/evil|')" \
+      "X-Hub-Signature-256: sha256=$(sign "$REPO_CREATED")")"
+
+# GitHub still sends the legacy SHA-1 header; accepting it would defeat the check.
+check "legacy sha1-only signature is rejected" 401 \
+  "$(post_raw repository "$REPO_CREATED" \
+      "X-Hub-Signature: sha1=$(printf '%s' "$REPO_CREATED" | openssl dgst -sha1 -hmac "$SECRET" | sed 's/^.*= *//')")"
+
+# --- normal operation -------------------------------------------------------
+check "POST /github_webhook (non-repository object)" 200 "$(post organization "$IGNORED")"
+check "POST /github_webhook (repository/deleted)" 200 "$(post repository "$REPO_DELETED")"
 check "GET /nope (unknown route)" 404 "$(get /nope)"
+check "POST /github_webhook (malformed JSON)" 400 "$(post repository 'not json')"
 
-check "POST /github_webhook (malformed JSON)" 400 \
-  "$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/github_webhook" \
-      -H 'Content-Type: application/json' -H 'X-GitHub-Event: repository' \
-      -d 'not json')"
-
-# An event we DO act on. The container runs with a dummy token, so the GitHub
-# call behind this fails -- which is the point. The work is acknowledged with 202
-# and runs off the request thread, and the failure must be logged and contained.
-# This is the regression test for exit(1) in the request path, which used to take
-# the whole server down mid-webhook.
-check "POST /github_webhook (repository/created)" 202 \
-  "$(post repository '{"action":"created","repository":{"full_name":"acme/demo","default_branch":"main"},"sender":{"login":"acme-bot"}}')"
+# An event we DO act on. The container runs with a dummy token, so the GitHub call
+# behind this fails -- which is the point. The work is acknowledged with 202 and
+# runs off the request thread; the failure must be logged and contained. This is
+# the regression test for exit(1) in the request path, which used to take the
+# whole server down mid-webhook.
+check "POST /github_webhook (repository/created, signed)" 202 "$(post repository "$REPO_CREATED")"
 
 # Give the background thread a moment to fail and log.
 sleep 3
 
 check "server still serving after a failed background job" 404 "$(get /nope)"
 
-if [ -n "$CONTAINER" ]; then
-  if logs | grep -qE '\[ERROR\].*processing repository/created'; then
-    echo "ok    background failure was logged, not fatal"
-  else
-    echo "FAIL  expected a logged [ERROR] for the failed repository/created job"
-    failures=$((failures + 1))
-  fi
-fi
-
+# --- log assertions ---------------------------------------------------------
+check_log "background failure was logged, not fatal" '\[ERROR\].*processing repository/created'
 # $stdout.sync must keep working or docker logs go silent -- see issue #6.
+check_log "[INFO] output reaches docker logs" '\[INFO\] Ignoring object'
+check_log "rejections are logged" '\[ERROR\] Rejecting webhook'
+# The secret must never appear in logs, nor a valid signature for a known body.
 if [ -n "$CONTAINER" ]; then
-  if logs | grep -q '\[INFO\] Ignoring object'; then
-    echo "ok    [INFO] output reaches docker logs"
-  else
-    echo "FAIL  no [INFO] output in docker logs (\$stdout.sync regression?)"
+  if logs | grep -q "$SECRET"; then
+    echo "FAIL  webhook secret leaked into the logs"
     failures=$((failures + 1))
+  else
+    echo "ok    webhook secret never appears in the logs"
   fi
 fi
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -20,6 +20,8 @@ end
 class AppSpec < SpecCase
   include Rack::Test::Methods
 
+  SECRET = 'test-webhook-secret'
+
   def app
     GithubWebhooks::App
   end
@@ -28,6 +30,12 @@ class AppSpec < SpecCase
     super
     @handler = RecordingHandler.new
     install_handler(@handler)
+    GithubWebhooks::App.webhook_secret = SECRET
+  end
+
+  def teardown
+    GithubWebhooks::App.webhook_secret = nil
+    super
   end
 
   def install_handler(handler)
@@ -36,10 +44,19 @@ class AppSpec < SpecCase
     GithubWebhooks::App.executor = GithubWebhooks::App::INLINE_EXECUTOR
   end
 
-  def deliver(event, payload)
-    post '/github_webhook', JSON.generate(payload),
-         'CONTENT_TYPE' => 'application/json',
-         'HTTP_X_GITHUB_EVENT' => event
+  def signature_for(body, secret: SECRET)
+    "sha256=#{OpenSSL::HMAC.hexdigest('sha256', secret, body)}"
+  end
+
+  # Posts a correctly signed request, the way GitHub would.
+  def deliver(event, payload, headers = {})
+    body = JSON.generate(payload)
+    send_raw(body, { 'HTTP_X_GITHUB_EVENT' => event,
+                     'HTTP_X_HUB_SIGNATURE_256' => signature_for(body) }.merge(headers))
+  end
+
+  def send_raw(body, headers = {})
+    post '/github_webhook', body, { 'CONTENT_TYPE' => 'application/json' }.merge(headers)
   end
 
   def test_acknowledges_repository_created_with_202_and_runs_the_handler
@@ -80,16 +97,17 @@ class AppSpec < SpecCase
   end
 
   def test_missing_event_header_is_ignored_rather_than_crashing
-    post '/github_webhook', JSON.generate('action' => 'created'),
-         'CONTENT_TYPE' => 'application/json'
+    body = JSON.generate('action' => 'created')
+    send_raw(body, 'HTTP_X_HUB_SIGNATURE_256' => signature_for(body))
 
     assert_equal 200, last_response.status
     assert_logged(/Ignoring object = unknown/)
   end
 
   def test_rejects_unparseable_json
-    post '/github_webhook', 'not json at all', 'CONTENT_TYPE' => 'application/json',
-                                               'HTTP_X_GITHUB_EVENT' => 'repository'
+    send_raw('not json at all',
+             'HTTP_X_GITHUB_EVENT' => 'repository',
+             'HTTP_X_HUB_SIGNATURE_256' => signature_for('not json at all'))
 
     assert_equal 400, last_response.status
     assert_empty @handler.payloads
@@ -97,8 +115,9 @@ class AppSpec < SpecCase
   end
 
   def test_rejects_a_json_body_that_is_not_an_object
-    post '/github_webhook', '["a","b"]', 'CONTENT_TYPE' => 'application/json',
-                                         'HTTP_X_GITHUB_EVENT' => 'repository'
+    send_raw('["a","b"]',
+             'HTTP_X_GITHUB_EVENT' => 'repository',
+             'HTTP_X_HUB_SIGNATURE_256' => signature_for('["a","b"]'))
 
     assert_equal 400, last_response.status
   end
@@ -130,5 +149,110 @@ class AppSpec < SpecCase
     get '/nope'
 
     assert_equal 404, last_response.status
+  end
+end
+
+# Before this existed, anyone who learned the URL could drive privileged calls
+# against the stored GitHub token.
+class SignatureVerificationSpec < SpecCase
+  include Rack::Test::Methods
+
+  SECRET = 'test-webhook-secret'
+  PAYLOAD = '{"action":"created","repository":{"full_name":"acme/demo"}}'
+
+  def app
+    GithubWebhooks::App
+  end
+
+  def setup
+    super
+    @handler = RecordingHandler.new
+    GithubWebhooks::App.repository_handler = @handler
+    GithubWebhooks::App.executor = GithubWebhooks::App::INLINE_EXECUTOR
+    GithubWebhooks::App.webhook_secret = SECRET
+  end
+
+  def teardown
+    GithubWebhooks::App.webhook_secret = nil
+    super
+  end
+
+  def signature_for(body, secret: SECRET)
+    "sha256=#{OpenSSL::HMAC.hexdigest('sha256', secret, body)}"
+  end
+
+  def deliver(body, headers = {})
+    post '/github_webhook', body,
+         { 'CONTENT_TYPE' => 'application/json',
+           'HTTP_X_GITHUB_EVENT' => 'repository' }.merge(headers)
+  end
+
+  def test_accepts_a_correctly_signed_request
+    deliver(PAYLOAD, 'HTTP_X_HUB_SIGNATURE_256' => signature_for(PAYLOAD))
+
+    assert_equal 202, last_response.status
+    assert_equal 1, @handler.payloads.length
+  end
+
+  def test_rejects_a_request_with_no_signature
+    deliver(PAYLOAD)
+
+    assert_equal 401, last_response.status
+    assert_empty @handler.payloads
+    assert_logged(/no X-Hub-Signature-256 header/)
+  end
+
+  def test_rejects_a_garbage_signature
+    deliver(PAYLOAD, 'HTTP_X_HUB_SIGNATURE_256' => 'sha256=deadbeef')
+
+    assert_equal 401, last_response.status
+    assert_empty @handler.payloads
+    assert_logged(/invalid X-Hub-Signature-256/)
+  end
+
+  def test_rejects_a_signature_computed_with_the_wrong_secret
+    deliver(PAYLOAD, 'HTTP_X_HUB_SIGNATURE_256' => signature_for(PAYLOAD, secret: 'not-the-secret'))
+
+    assert_equal 401, last_response.status
+    assert_empty @handler.payloads
+  end
+
+  # The signature must cover the bytes actually delivered, not some other body.
+  def test_rejects_a_tampered_body
+    tampered = PAYLOAD.sub('acme/demo', 'attacker/evil')
+
+    deliver(tampered, 'HTTP_X_HUB_SIGNATURE_256' => signature_for(PAYLOAD))
+
+    assert_equal 401, last_response.status
+    assert_empty @handler.payloads
+  end
+
+  # GitHub still sends the legacy SHA-1 header; accepting it would undo the point.
+  def test_rejects_a_request_carrying_only_the_legacy_sha1_header
+    sha1 = "sha1=#{OpenSSL::HMAC.hexdigest('sha1', SECRET, PAYLOAD)}"
+
+    deliver(PAYLOAD, 'HTTP_X_HUB_SIGNATURE' => sha1)
+
+    assert_equal 401, last_response.status
+    assert_empty @handler.payloads
+  end
+
+  def test_never_logs_the_secret_or_the_expected_signature
+    deliver(PAYLOAD, 'HTTP_X_HUB_SIGNATURE_256' => 'sha256=deadbeef')
+
+    refute_logged(/#{SECRET}/)
+    refute_logged(/#{OpenSSL::HMAC.hexdigest('sha256', SECRET, PAYLOAD)}/)
+  end
+
+  # Belt and braces: Settings refuses to boot without a secret, but the request
+  # path must not fail open either.
+  def test_refuses_to_process_when_no_secret_is_configured
+    GithubWebhooks::App.webhook_secret = nil
+
+    deliver(PAYLOAD, 'HTTP_X_HUB_SIGNATURE_256' => signature_for(PAYLOAD))
+
+    assert_equal 500, last_response.status
+    assert_empty @handler.payloads
+    assert_logged(/No webhook secret configured/)
   end
 end

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -13,9 +13,14 @@ class SettingsSpec < SpecCase
     end
   end
 
-  def test_loads_the_github_token
-    with_properties("githubToken=abc123\n") do |path|
-      assert_equal 'abc123', GithubWebhooks::Settings.load(path).github_token
+  VALID = "githubToken=abc123\nwebhookSecret=s3cr3t\n"
+
+  def test_loads_the_github_token_and_webhook_secret
+    with_properties(VALID) do |path|
+      settings = GithubWebhooks::Settings.load(path)
+
+      assert_equal 'abc123', settings.github_token
+      assert_equal 's3cr3t', settings.webhook_secret
     end
   end
 
@@ -28,13 +33,30 @@ class SettingsSpec < SpecCase
   end
 
   def test_raises_when_the_token_is_absent
-    with_properties("somethingElse=x\n") do |path|
+    with_properties("webhookSecret=s3cr3t\n") do |path|
       assert_raises(GithubWebhooks::ConfigurationError) { GithubWebhooks::Settings.load(path) }
     end
   end
 
   def test_raises_when_the_token_is_blank
-    with_properties("githubToken=   \n") do |path|
+    with_properties("githubToken=   \nwebhookSecret=s3cr3t\n") do |path|
+      assert_raises(GithubWebhooks::ConfigurationError) { GithubWebhooks::Settings.load(path) }
+    end
+  end
+
+  # Fail closed: booting without a secret would leave the endpoint open.
+  def test_raises_when_the_webhook_secret_is_absent
+    with_properties("githubToken=abc123\n") do |path|
+      error = assert_raises(GithubWebhooks::ConfigurationError) do
+        GithubWebhooks::Settings.load(path)
+      end
+
+      assert_match(/webhookSecret is missing/, error.message)
+    end
+  end
+
+  def test_raises_when_the_webhook_secret_is_blank
+    with_properties("githubToken=abc123\nwebhookSecret=  \n") do |path|
       assert_raises(GithubWebhooks::ConfigurationError) { GithubWebhooks::Settings.load(path) }
     end
   end


### PR DESCRIPTION
`POST /github_webhook` accepted anything from anyone. It then acted on that input using a stored GitHub token with repo-admin scope — creating commits, changing repository settings, rewriting branch protection, opening issues. **Anyone who learned the URL could drive all of it.** This was a larger exposure than the CVEs fixed in #14.

Every delivery is now checked against an HMAC-SHA256 of the raw request body under a shared secret, per [GitHub's documented scheme](https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries). Anything that does not verify is rejected with `401` before any processing.

> [!WARNING]
> **Breaking change — action required on deploy.**
>
> Add `webhookSecret` to `.webhook_properties` **and** set the same value in the webhook's **Secret** field in GitHub (repo or org → Settings → Webhooks → your webhook → Secret). Generate one with `openssl rand -hex 32`.
>
> The server **refuses to start** without it. That is deliberate: booting without a secret would leave the endpoint exactly as open as it is today, and a warning would get ignored.

## Design decisions

| Decision | Why |
| --- | --- |
| Fail closed at boot, *and* refuse to process (500) if the secret is somehow unset at request time | Two independent guards; failing open would defeat the whole check |
| Body read once in a `before` filter | The signature covers the **raw bytes** — re-serializing parsed JSON would not reproduce them |
| `Rack::Utils.secure_compare` | Constant-time; a plain `==` leaks how much of the signature was correct through timing |
| Legacy SHA-1 `X-Hub-Signature` **not** accepted | GitHub still sends it; honoring it would undo the point |
| Never log the secret or the *expected* signature | The expected value is enough to forge the next request |

## Verification

**40 specs, 108 assertions, all passing.** New `SignatureVerificationSpec` covers:

- correctly signed request → `202`, handler runs
- no signature header → `401`, handler not called
- garbage signature → `401`
- signature computed with the **wrong secret** → `401`
- **tampered body** (valid signature, different bytes) → `401`
- sha1-only legacy header → `401`
- secret unset at request time → `500`, nothing processed
- neither the secret nor a valid signature for a known body appears in the logs

Against a real container, `script/smoke_test.sh` now runs all four rejection cases plus the happy path — 14 checks, all green:

```
ok    unsigned request is rejected (HTTP 401)
ok    garbage signature is rejected (HTTP 401)
ok    tampered body is rejected (HTTP 401)
ok    legacy sha1-only signature is rejected (HTTP 401)
...
ok    POST /github_webhook (repository/created, signed) (HTTP 202)
ok    server still serving after a failed background job (HTTP 404)
ok    webhook secret never appears in the logs
```

The shell HMAC used by the smoke test was checked to agree byte-for-byte with `OpenSSL::HMAC.hexdigest` in Ruby, so it is testing the real thing rather than agreeing with itself.

CI also now asserts the image **refuses to boot** with no `webhookSecret`:

```
[ERROR] webhookSecret is missing or empty in the properties file. Set the same
value here and in the webhook's Secret field in GitHub.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)