### PR TITLE
Add a Ruby 4.0 CI lane; keep the image on 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,22 @@ on:
 
 jobs:
   specs:
-    name: Specs
+    name: Specs (ruby ${{ matrix.ruby }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.4 is what the image ships (see Dockerfile). 4.0 is forward-compat
+        # signal only -- it is not what gets deployed, so it must not block a
+        # merge; it exists to catch a break before we choose to move.
+        ruby: ['3.4', '4.0']
+    continue-on-error: ${{ matrix.ruby == '4.0' }}
     steps:
       - uses: actions/checkout@v5
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4'
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
       - run: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ https://github.com/jimzucker/github-webhooks
 
 ##### Instructions to run Manually outside of Docker from github source
 
-Requires Ruby 3.4 or newer (see the `Dockerfile` for the version this is built and tested against).
+Requires Ruby 3.4 or newer. The published image ships **Ruby 3.4** (see the `Dockerfile`); CI additionally runs the suite against **Ruby 4.0** as a forward-compatibility signal, so a break there is visible before the image moves.
 
 1. Install the dependencies:
 
@@ -178,6 +178,8 @@ Requires Ruby 3.4 or newer (see the `Dockerfile` for the version this is built a
 bundle install
 bundle exec rake
 ```
+
+CI runs this on Ruby 3.4 (required to pass) and Ruby 4.0 (advisory).
 
 ##### Layout
 


### PR DESCRIPTION
Evaluation of Dependabot's `ruby:3.4` → `ruby:4.0` bump (#15), done on its own branch per the one-major-per-PR rule.

## Ruby 4.0.6 works completely

Everything I could test passes on 4.0.6:

| Check | Result |
| --- | --- |
| `bundle lock --update` | Resolves to **identical** gem versions |
| Spec suite | **40 runs, 108 assertions, 0 failures** |
| Image build | Clean — `puma`, `nio4r`, `json` native extensions all compile |
| Container boot | `Sinatra 4.2.1` / `Ruby 4.0.6 +PRISM`, `Listening on http://0.0.0.0:4567` |
| Smoke test | **All 14 checks pass**, including every signature-rejection case |

So this is not a "it's broken" call.

## Why not take it yet

4.0.6 was released **2026-07-14** — about two weeks ago. Ruby 3.4 is the mature supported line, and there's no benefit here worth putting a two-week-old major runtime under a service that holds a repo-admin token.

Two further findings argued against merging as-is:

1. **Image grows 286 MB → 314 MB** (+28 MB) for no functional gain.
2. **Bundler version conflict.** Ruby 4.0 ships bundler 4.0.16, but `Gemfile.lock` pins `BUNDLED WITH 2.6.9`, so the image downloads bundler 2.6.9 and then emits ~20 `already initialized constant Gem::Platform::*` warnings under `bundle exec`. Silencing that means moving the lockfile to **bundler 4** — a second major bump in the same change.

   Worth noting the deployed container runs `ruby github_webhooks.rb` directly and never invokes bundler, so it boots clean either way. The noise is confined to `bundle exec` (i.e. the spec job).

## What this PR does instead

The spec job now runs a `[3.4, 4.0]` matrix, with 4.0 marked `continue-on-error` so it **reports without blocking a merge**:

```yaml
matrix:
  ruby: ['3.4', '4.0']
continue-on-error: ${{ matrix.ruby == '4.0' }}
```

That converts a one-time decision into a standing signal — a 4.0 regression shows up immediately, and when you do want to move, it's a one-line Dockerfile change against CI that's already known green.

Closes #15.

One thing I left alone: Dependabot will re-offer a major bump when 4.1 lands. If that's unwanted noise, an `ignore` entry for `version-update:semver-major` on the `ruby` docker dependency would suppress it while still getting 3.4.x patches — say the word and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)