### PR TITLE
Stop Dependabot re-offering the Ruby major bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,18 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      # Ruby 4.0 was evaluated in #19 and deliberately declined: it works
+      # completely, but 3.4 is the mature supported line and there is no gain
+      # worth a brand-new major runtime here. CI already runs the suite against
+      # 4.0 as an advisory lane, so the forward-compat signal is covered without
+      # a PR every week.
+      #
+      # This ignores MAJOR bumps only -- 3.4 -> 3.5 still gets offered.
+      # Remove this block when you want to move to the next major.
+      - dependency-name: ruby
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
The `ruby 3.4 -> 4.0` bump came back as #20 one day after #15 was closed and #19 evaluated it.

**Why closing the PR didn't suppress it:** #16's multi-stage rewrite changed the pin from `ruby:3.4` to `ruby:3.4-slim`. Dependabot treats that as a *different dependency spec* than the one that was rejected, so it opened a fresh PR rather than honoring the earlier close. It would keep doing that on every pin change.

So this adds an explicit ignore, scoped as narrowly as possible:

```yaml
ignore:
  - dependency-name: ruby
    update-types:
      - version-update:semver-major
```

**Major bumps for `ruby` only.** Minor bumps (`3.4` → `3.5`) still get offered, as do all other docker, bundler, and github-actions updates.

## This does not lose the signal

CI has run the suite against Ruby 4.0 as an advisory `continue-on-error` lane since #19, so a 4.0 regression still surfaces on every push — it just doesn't cost a PR every week. The ignore block carries a comment saying exactly that, and to remove it when you want the next major.

To reverse: delete the `ignore:` block. Dependabot will offer 4.x again on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)